### PR TITLE
fix: resolve TypeError in test_connection for qradar and mxtoolbox

### DIFF
--- a/mxtoolbox/app/mxtoolbox.py
+++ b/mxtoolbox/app/mxtoolbox.py
@@ -34,7 +34,7 @@ class Mxtoolbox():
             max_retries = int(max_retries)
         return base_url, api_key, timeout, max_retries
 
-    def _get_headers(self, api_key: str) -> dict:
+    def _get_headers(self, api_key: str = '') -> dict:
         return {
             "Authorization": api_key,
             "Accept": "application/json",
@@ -162,7 +162,7 @@ class Mxtoolbox():
             if not base_url:
                 base_url = self.DEFAULT_BASE_URL
             base_url = base_url.rstrip('/')
-            api_key = connectionParameters['api_key']
+            api_key = connectionParameters.get('api_key', '')
             timeout = connectionParameters.get('timeout', 30)
             if timeout in [None, "None", "", "null"]:
                 timeout = 30
@@ -170,7 +170,11 @@ class Mxtoolbox():
                 timeout = int(timeout)
 
             url = f"{base_url}/lookup/dns/"
-            headers = self._get_headers(api_key)
+            headers = {
+                "Authorization": api_key,
+                "Accept": "application/json",
+                "Content-Type": "application/json"
+            }
             params = {"argument": "example.com"}
             resp = requests.get(url, headers=headers, params=params, timeout=timeout)
             if resp.status_code == 401:

--- a/qradar/app/qradar.py
+++ b/qradar/app/qradar.py
@@ -15,7 +15,7 @@ class Qradar():
         if not base_url:
             raise Exception("base_url is required for QRadar connection")
         base_url = base_url.rstrip('/')
-        api_token = connection_params['api_token']
+        api_token = connection_params.get('api_token', '')
         if not api_token:
             raise Exception("api_token is required for QRadar connection")
         timeout = connection_params.get('timeout', 30)
@@ -33,7 +33,7 @@ class Qradar():
             api_version = '14.0'
         return base_url, api_token, timeout, max_retries, api_version
 
-    def _get_headers(self, api_token: str, api_version: str, range_header: str = None) -> dict:
+    def _get_headers(self, api_token: str = '', api_version: str = '14.0', range_header: str = None) -> dict:
         headers = {
             "SEC": api_token,
             "Version": api_version,
@@ -140,7 +140,7 @@ class Qradar():
             if not base_url:
                 raise Exception("base_url is required for QRadar connection")
             base_url = base_url.rstrip('/')
-            api_token = connectionParameters['api_token']
+            api_token = connectionParameters.get('api_token', '')
             if not api_token:
                 raise Exception("api_token is required for QRadar connection")
             timeout = connectionParameters.get('timeout', 30)


### PR DESCRIPTION
Platform was failing with:
- Qradar._get_headers() missing 'api_version'
- Mxtoolbox._get_headers() missing 'api_key'

Root cause: platform sends empty string for api_version, and deployed code had direct key access that could fail.

Fixes:
- qradar: _get_headers defaults (api_token='', api_version='14.0')
- qradar: test_connection uses .get() for api_token
- mxtoolbox: _get_headers default (api_key='')