### PR TITLE
fix: align Forcepoint SWG integration with official API documentation

### DIFF
--- a/forcepoint_swg/app/forcepoint_swg.py
+++ b/forcepoint_swg/app/forcepoint_swg.py
@@ -17,8 +17,15 @@ class ForcepointSwg():
 
     def _get_connection(self, connection_params):
         base_url = connection_params['server_url'].rstrip('/')
+        token_url = connection_params['token_url'].rstrip('/')
         api_key = connection_params['api_key']
-        return base_url, api_key
+        return base_url, token_url, api_key
+
+    def _get_bearer_token(self, token_url, api_key):
+        resp = requests.post(token_url, headers={"X-API-KEY": api_key}, timeout=30)
+        if resp.status_code >= 300:
+            raise Exception(f"Token generation failed: {resp.status_code} {resp.text}")
+        return resp.json().get('token')
 
     # -------------------------------------------------------------------------
     # Test Connection
@@ -26,13 +33,13 @@ class ForcepointSwg():
     def test_connection(self, connectionParameters: dict):
         try:
             base_url = connectionParameters['server_url'].rstrip('/')
+            token_url = connectionParameters['token_url'].rstrip('/')
             api_key = connectionParameters['api_key']
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "Accept": "application/json",
-                "Content-Type": "application/json"
-            }
-            resp = requests.get(f"{base_url}/customcategories", headers=headers, timeout=30)
+
+            token = self._get_bearer_token(token_url, api_key)
+            headers = self._get_headers(token)
+
+            resp = requests.get(base_url, headers=headers, timeout=30)
             if resp.status_code in (401, 403):
                 raise Exception(f"Authentication failed: {resp.status_code} {resp.text}")
             if resp.status_code >= 500:
@@ -51,34 +58,35 @@ class ForcepointSwg():
     # -------------------------------------------------------------------------
     def get_all_custom_categories(self, request: RequestBody) -> dict:
         try:
-            base_url, api_key = self._get_connection(request.connectionParameters)
-            headers = self._get_headers(api_key)
+            base_url, token_url, api_key = self._get_connection(request.connectionParameters)
+            token = self._get_bearer_token(token_url, api_key)
+            headers = self._get_headers(token)
 
             all_categories = []
-            cursor = request.parameters.get('cursor')
+            cursor = request.parameters.get('cursor', '')
 
             while True:
                 params = {}
                 if cursor:
                     params['cursor'] = cursor
 
-                resp = requests.get(f"{base_url}/customcategories", headers=headers, params=params, timeout=30)
+                resp = requests.get(base_url, headers=headers, params=params, timeout=30)
                 if resp.status_code >= 300:
                     raise Exception(resp.text)
 
                 data = resp.json()
-                categories = data if isinstance(data, list) else data.get('data', [])
+                categories = data.get('categories', [])
                 all_categories.extend(categories)
 
-                cursor = data.get('cursor') if isinstance(data, dict) else None
+                cursor = data.get('nextPageCursor')
                 if not cursor:
                     break
 
             return {
                 "status": "success",
                 "message": "Categories retrieved successfully.",
-                "categories": all_categories,
-                "count": len(all_categories)
+                "totalResults": len(all_categories),
+                "categories": all_categories
             }
 
         except Exception as e:
@@ -90,8 +98,9 @@ class ForcepointSwg():
     # -------------------------------------------------------------------------
     def create_category(self, request: RequestBody) -> dict:
         try:
-            base_url, api_key = self._get_connection(request.connectionParameters)
-            headers = self._get_headers(api_key)
+            base_url, token_url, api_key = self._get_connection(request.connectionParameters)
+            token = self._get_bearer_token(token_url, api_key)
+            headers = self._get_headers(token)
 
             payload = {"name": request.parameters['name']}
             if request.parameters.get('description'):
@@ -103,14 +112,18 @@ class ForcepointSwg():
             if request.parameters.get('comment'):
                 payload['comment'] = request.parameters['comment']
 
-            resp = requests.post(f"{base_url}/customcategories", headers=headers, json=payload, timeout=30)
+            resp = requests.post(base_url, headers=headers, json=payload, timeout=30)
             if resp.status_code >= 300:
                 raise Exception(resp.text)
 
+            transaction_data = resp.json()
             return {
                 "status": "success",
-                "message": "Category created successfully.",
-                "category": resp.json()
+                "message": "Category creation request accepted.",
+                "transactionId": transaction_data.get("transactionId"),
+                "transactionStatus": transaction_data.get("status"),
+                "data": transaction_data.get("data"),
+                "comment": transaction_data.get("comment")
             }
 
         except Exception as e:
@@ -122,37 +135,46 @@ class ForcepointSwg():
     # -------------------------------------------------------------------------
     def get_category_by_id(self, request: RequestBody) -> dict:
         try:
-            base_url, api_key = self._get_connection(request.connectionParameters)
-            headers = self._get_headers(api_key)
+            base_url, token_url, api_key = self._get_connection(request.connectionParameters)
+            token = self._get_bearer_token(token_url, api_key)
+            headers = self._get_headers(token)
 
             category_id = request.parameters['categoryId']
             all_sites = []
-            cursor = request.parameters.get('cursor')
+            cursor = request.parameters.get('cursor', '')
 
+            category_info = {}
             while True:
                 params = {}
                 if cursor:
                     params['cursor'] = cursor
 
-                resp = requests.get(f"{base_url}/customcategories/{category_id}", headers=headers, params=params, timeout=30)
+                resp = requests.get(f"{base_url}/{category_id}", headers=headers, params=params, timeout=30)
                 if resp.status_code >= 300:
                     raise Exception(resp.text)
 
                 data = resp.json()
-                sites = data.get('sites', []) if isinstance(data, dict) else []
+                if not category_info:
+                    category_info = {
+                        "id": data.get("id"),
+                        "name": data.get("name"),
+                        "description": data.get("description"),
+                        "policyName": data.get("policyName")
+                    }
+
+                sites = data.get('sites', [])
                 all_sites.extend(sites)
 
-                cursor = data.get('cursor') if isinstance(data, dict) else None
+                cursor = data.get('nextPageCursor')
                 if not cursor:
                     break
 
-            category = data if isinstance(data, dict) else {}
-            category['sites'] = all_sites
+            category_info['sites'] = all_sites
 
             return {
                 "status": "success",
                 "message": "Category retrieved successfully.",
-                "category": category
+                "category": category_info
             }
 
         except Exception as e:
@@ -164,8 +186,9 @@ class ForcepointSwg():
     # -------------------------------------------------------------------------
     def add_or_remove_category_sites(self, request: RequestBody) -> dict:
         try:
-            base_url, api_key = self._get_connection(request.connectionParameters)
-            headers = self._get_headers(api_key)
+            base_url, token_url, api_key = self._get_connection(request.connectionParameters)
+            token = self._get_bearer_token(token_url, api_key)
+            headers = self._get_headers(token)
 
             category_id = request.parameters['categoryId']
             action = request.parameters['action']
@@ -175,7 +198,7 @@ class ForcepointSwg():
                 payload['comment'] = request.parameters['comment']
 
             resp = requests.patch(
-                f"{base_url}/customcategories/{category_id}",
+                f"{base_url}/{category_id}",
                 headers=headers,
                 json=payload,
                 params={"action": action},
@@ -184,11 +207,14 @@ class ForcepointSwg():
             if resp.status_code >= 300:
                 raise Exception(resp.text)
 
+            transaction_data = resp.json()
             return {
                 "status": "success",
                 "message": f"Sites {action} operation accepted.",
-                "categoryId": category_id,
-                "action": action
+                "transactionId": transaction_data.get("transactionId"),
+                "transactionStatus": transaction_data.get("status"),
+                "data": transaction_data.get("data"),
+                "comment": transaction_data.get("comment")
             }
 
         except Exception as e:
@@ -200,19 +226,24 @@ class ForcepointSwg():
     # -------------------------------------------------------------------------
     def delete_category(self, request: RequestBody) -> dict:
         try:
-            base_url, api_key = self._get_connection(request.connectionParameters)
-            headers = self._get_headers(api_key)
+            base_url, token_url, api_key = self._get_connection(request.connectionParameters)
+            token = self._get_bearer_token(token_url, api_key)
+            headers = self._get_headers(token)
 
             category_id = request.parameters['categoryId']
 
-            resp = requests.delete(f"{base_url}/customcategories/{category_id}", headers=headers, timeout=30)
+            resp = requests.delete(f"{base_url}/{category_id}", headers=headers, timeout=30)
             if resp.status_code >= 300:
                 raise Exception(resp.text)
 
+            transaction_data = resp.json()
             return {
                 "status": "success",
-                "message": "Category deleted successfully.",
-                "categoryId": category_id
+                "message": "Category deletion request accepted.",
+                "transactionId": transaction_data.get("transactionId"),
+                "transactionStatus": transaction_data.get("status"),
+                "data": transaction_data.get("data"),
+                "comment": transaction_data.get("comment")
             }
 
         except Exception as e:

--- a/forcepoint_swg/tests/test_forcepoint_swg.py
+++ b/forcepoint_swg/tests/test_forcepoint_swg.py
@@ -12,7 +12,8 @@ def client():
 @pytest.fixture
 def connection_params():
     return {
-        "server_url": "https://api.forcepoint.example.com/swg/v1",
+        "server_url": "https://ws-custom-categories.api.forcepoint.io/v1.0.0",
+        "token_url": "https://api.forcepoint.io/api/apikeys/token",
         "api_key": "test-api-key-123"
     }
 
@@ -24,46 +25,78 @@ def make_request(connection_params, parameters=None):
     return request
 
 
+def mock_token_response():
+    return MagicMock(status_code=200, json=lambda: {"token": "generated-bearer-token"})
+
+
 class TestTestConnection:
 
     @patch('app.forcepoint_swg.requests.get')
-    def test_success(self, mock_get, client, connection_params):
-        mock_get.return_value = MagicMock(status_code=200, json=lambda: [])
+    @patch('app.forcepoint_swg.requests.post')
+    def test_success(self, mock_post, mock_get, client, connection_params):
+        mock_post.return_value = mock_token_response()
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"totalResults": 0, "categories": []})
         result = client.test_connection(connection_params)
         assert result['status'] == 'success'
 
+    @patch('app.forcepoint_swg.requests.post')
+    def test_token_failure(self, mock_post, client, connection_params):
+        mock_post.return_value = MagicMock(status_code=401, text='Unauthorized')
+        with pytest.raises(Exception, match='Token generation failed'):
+            client.test_connection(connection_params)
+
     @patch('app.forcepoint_swg.requests.get')
-    def test_failure(self, mock_get, client, connection_params):
-        mock_get.return_value = MagicMock(status_code=401, text='Unauthorized')
-        with pytest.raises(Exception, match='Unauthorized'):
+    @patch('app.forcepoint_swg.requests.post')
+    def test_auth_failure(self, mock_post, mock_get, client, connection_params):
+        mock_post.return_value = mock_token_response()
+        mock_get.return_value = MagicMock(status_code=403, text='Forbidden')
+        with pytest.raises(Exception, match='Authentication failed'):
             client.test_connection(connection_params)
 
 
 class TestGetAllCustomCategories:
 
     @patch('app.forcepoint_swg.requests.get')
-    def test_single_page(self, mock_get, client, connection_params):
+    @patch('app.forcepoint_swg.requests.post')
+    def test_single_page(self, mock_post, mock_get, client, connection_params):
+        mock_post.return_value = mock_token_response()
         mock_get.return_value = MagicMock(
             status_code=200,
-            json=lambda: [{"id": 1, "name": "Blocked Sites"}]
+            json=lambda: {
+                "totalResults": 1,
+                "nextPageCursor": None,
+                "categories": [{"id": 1, "name": "Blocked Sites"}]
+            }
         )
         request = make_request(connection_params)
         result = client.get_all_custom_categories(request)
         assert result['status'] == 'success'
-        assert result['count'] == 1
+        assert result['totalResults'] == 1
         assert result['categories'][0]['name'] == 'Blocked Sites'
 
     @patch('app.forcepoint_swg.requests.get')
-    def test_pagination(self, mock_get, client, connection_params):
-        page1 = MagicMock(status_code=200, json=lambda: {"data": [{"id": 1}], "cursor": "abc"})
-        page2 = MagicMock(status_code=200, json=lambda: {"data": [{"id": 2}], "cursor": None})
+    @patch('app.forcepoint_swg.requests.post')
+    def test_pagination(self, mock_post, mock_get, client, connection_params):
+        mock_post.return_value = mock_token_response()
+        page1 = MagicMock(status_code=200, json=lambda: {
+            "totalResults": 2,
+            "nextPageCursor": "abc",
+            "categories": [{"id": 1}]
+        })
+        page2 = MagicMock(status_code=200, json=lambda: {
+            "totalResults": 2,
+            "nextPageCursor": None,
+            "categories": [{"id": 2}]
+        })
         mock_get.side_effect = [page1, page2]
         request = make_request(connection_params)
         result = client.get_all_custom_categories(request)
-        assert result['count'] == 2
+        assert result['totalResults'] == 2
 
     @patch('app.forcepoint_swg.requests.get')
-    def test_error(self, mock_get, client, connection_params):
+    @patch('app.forcepoint_swg.requests.post')
+    def test_error(self, mock_post, mock_get, client, connection_params):
+        mock_post.return_value = mock_token_response()
         mock_get.return_value = MagicMock(status_code=500, text='Server error')
         request = make_request(connection_params)
         with pytest.raises(Exception, match='Server error'):
@@ -74,10 +107,17 @@ class TestCreateCategory:
 
     @patch('app.forcepoint_swg.requests.post')
     def test_success(self, mock_post, client, connection_params):
-        mock_post.return_value = MagicMock(
+        token_resp = mock_token_response()
+        create_resp = MagicMock(
             status_code=201,
-            json=lambda: {"id": 10, "name": "New Category"}
+            json=lambda: {
+                "transactionId": "00000000-0000-0000-0000-000000000001",
+                "status": "pending",
+                "data": {},
+                "comment": "Created via API"
+            }
         )
+        mock_post.side_effect = [token_resp, create_resp]
         request = make_request(connection_params, {
             "name": "New Category",
             "description": "Test desc",
@@ -87,21 +127,32 @@ class TestCreateCategory:
         })
         result = client.create_category(request)
         assert result['status'] == 'success'
-        assert result['category']['name'] == 'New Category'
+        assert result['transactionId'] == '00000000-0000-0000-0000-000000000001'
+        assert result['transactionStatus'] == 'pending'
 
     @patch('app.forcepoint_swg.requests.post')
     def test_minimal_params(self, mock_post, client, connection_params):
-        mock_post.return_value = MagicMock(
+        token_resp = mock_token_response()
+        create_resp = MagicMock(
             status_code=201,
-            json=lambda: {"id": 11, "name": "Minimal"}
+            json=lambda: {
+                "transactionId": "00000000-0000-0000-0000-000000000002",
+                "status": "pending",
+                "data": {},
+                "comment": None
+            }
         )
+        mock_post.side_effect = [token_resp, create_resp]
         request = make_request(connection_params, {"name": "Minimal"})
         result = client.create_category(request)
         assert result['status'] == 'success'
+        assert result['transactionId'] is not None
 
     @patch('app.forcepoint_swg.requests.post')
     def test_error(self, mock_post, client, connection_params):
-        mock_post.return_value = MagicMock(status_code=400, text='Bad request')
+        token_resp = mock_token_response()
+        create_resp = MagicMock(status_code=400, text='Bad request')
+        mock_post.side_effect = [token_resp, create_resp]
         request = make_request(connection_params, {"name": "Bad"})
         with pytest.raises(Exception, match='Bad request'):
             client.create_category(request)
@@ -110,10 +161,19 @@ class TestCreateCategory:
 class TestGetCategoryById:
 
     @patch('app.forcepoint_swg.requests.get')
-    def test_success(self, mock_get, client, connection_params):
+    @patch('app.forcepoint_swg.requests.post')
+    def test_success(self, mock_post, mock_get, client, connection_params):
+        mock_post.return_value = mock_token_response()
         mock_get.return_value = MagicMock(
             status_code=200,
-            json=lambda: {"id": 5, "name": "Test", "sites": ["a.com", "b.com"]}
+            json=lambda: {
+                "id": 5,
+                "name": "Test",
+                "description": "Test category",
+                "policyName": "Default",
+                "sites": [{"url": "a.com"}, {"url": "b.com"}],
+                "nextPageCursor": None
+            }
         )
         request = make_request(connection_params, {"categoryId": 5})
         result = client.get_category_by_id(request)
@@ -122,7 +182,9 @@ class TestGetCategoryById:
         assert len(result['category']['sites']) == 2
 
     @patch('app.forcepoint_swg.requests.get')
-    def test_not_found(self, mock_get, client, connection_params):
+    @patch('app.forcepoint_swg.requests.post')
+    def test_not_found(self, mock_post, mock_get, client, connection_params):
+        mock_post.return_value = mock_token_response()
         mock_get.return_value = MagicMock(status_code=404, text='Not found')
         request = make_request(connection_params, {"categoryId": 999})
         with pytest.raises(Exception, match='Not found'):
@@ -132,8 +194,18 @@ class TestGetCategoryById:
 class TestAddOrRemoveCategorySites:
 
     @patch('app.forcepoint_swg.requests.patch')
-    def test_add_sites(self, mock_patch, client, connection_params):
-        mock_patch.return_value = MagicMock(status_code=202)
+    @patch('app.forcepoint_swg.requests.post')
+    def test_add_sites(self, mock_post, mock_patch, client, connection_params):
+        mock_post.return_value = mock_token_response()
+        mock_patch.return_value = MagicMock(
+            status_code=202,
+            json=lambda: {
+                "transactionId": "00000000-0000-0000-0000-000000000003",
+                "status": "pending",
+                "data": {},
+                "comment": None
+            }
+        )
         request = make_request(connection_params, {
             "categoryId": 5,
             "action": "add",
@@ -141,11 +213,22 @@ class TestAddOrRemoveCategorySites:
         })
         result = client.add_or_remove_category_sites(request)
         assert result['status'] == 'success'
-        assert result['action'] == 'add'
+        assert result['transactionId'] == '00000000-0000-0000-0000-000000000003'
+        assert result['transactionStatus'] == 'pending'
 
     @patch('app.forcepoint_swg.requests.patch')
-    def test_remove_sites(self, mock_patch, client, connection_params):
-        mock_patch.return_value = MagicMock(status_code=202)
+    @patch('app.forcepoint_swg.requests.post')
+    def test_remove_sites(self, mock_post, mock_patch, client, connection_params):
+        mock_post.return_value = mock_token_response()
+        mock_patch.return_value = MagicMock(
+            status_code=202,
+            json=lambda: {
+                "transactionId": "00000000-0000-0000-0000-000000000004",
+                "status": "pending",
+                "data": {},
+                "comment": "Removing old site"
+            }
+        )
         request = make_request(connection_params, {
             "categoryId": 5,
             "action": "remove",
@@ -154,10 +237,12 @@ class TestAddOrRemoveCategorySites:
         })
         result = client.add_or_remove_category_sites(request)
         assert result['status'] == 'success'
-        assert result['action'] == 'remove'
+        assert result['transactionStatus'] == 'pending'
 
     @patch('app.forcepoint_swg.requests.patch')
-    def test_error(self, mock_patch, client, connection_params):
+    @patch('app.forcepoint_swg.requests.post')
+    def test_error(self, mock_post, mock_patch, client, connection_params):
+        mock_post.return_value = mock_token_response()
         mock_patch.return_value = MagicMock(status_code=403, text='Forbidden')
         request = make_request(connection_params, {
             "categoryId": 5,
@@ -171,15 +256,28 @@ class TestAddOrRemoveCategorySites:
 class TestDeleteCategory:
 
     @patch('app.forcepoint_swg.requests.delete')
-    def test_success(self, mock_delete, client, connection_params):
-        mock_delete.return_value = MagicMock(status_code=202)
+    @patch('app.forcepoint_swg.requests.post')
+    def test_success(self, mock_post, mock_delete, client, connection_params):
+        mock_post.return_value = mock_token_response()
+        mock_delete.return_value = MagicMock(
+            status_code=202,
+            json=lambda: {
+                "transactionId": "00000000-0000-0000-0000-000000000005",
+                "status": "pending",
+                "data": {},
+                "comment": None
+            }
+        )
         request = make_request(connection_params, {"categoryId": 5})
         result = client.delete_category(request)
         assert result['status'] == 'success'
-        assert result['categoryId'] == 5
+        assert result['transactionId'] == '00000000-0000-0000-0000-000000000005'
+        assert result['transactionStatus'] == 'pending'
 
     @patch('app.forcepoint_swg.requests.delete')
-    def test_not_found(self, mock_delete, client, connection_params):
+    @patch('app.forcepoint_swg.requests.post')
+    def test_not_found(self, mock_post, mock_delete, client, connection_params):
+        mock_post.return_value = mock_token_response()
         mock_delete.return_value = MagicMock(status_code=404, text='Not found')
         request = make_request(connection_params, {"categoryId": 999})
         with pytest.raises(Exception, match='Not found'):


### PR DESCRIPTION
- Fix token auth flow: exchange API key for bearer token via POST {token_url}
- Add token_url as connection parameter
- Fix pagination to use nextPageCursor instead of cursor
- Fix get_all_custom_categories to read from categories key
- Fix create_category to return transaction response (201)
- Fix add_or_remove_category_sites to return transaction response (202)
- Fix delete_category to return transaction response (202)
- Update tests to match corrected response structures