### PR TITLE
feat(opencti): add 5 new actions - get_indicators, get_relationships,…

### DIFF
--- a/opencti/app/opencti.py
+++ b/opencti/app/opencti.py
@@ -62,6 +62,71 @@ query StixDomainObjects($search: String, $types: [String], $first: Int) {
 }
 """
 
+INDICATORS_QUERY = """
+query Indicators($search: String, $filters: FilterGroup, $first: Int) {
+  indicators(search: $search, filters: $filters, first: $first) {
+    edges {
+      node {
+        id
+        name
+        pattern
+        pattern_type
+        confidence
+        valid_from
+        valid_until
+        objectLabel { value }
+        objectMarking { definition }
+        createdBy { name }
+      }
+    }
+  }
+}
+"""
+
+RELATIONSHIPS_QUERY = """
+query StixCoreRelationships($filters: FilterGroup, $first: Int) {
+  stixCoreRelationships(filters: $filters, first: $first) {
+    edges {
+      node {
+        id
+        relationship_type
+        start_time
+        stop_time
+        confidence
+        from { ... on BasicObject { id entity_type } ... on StixDomainObject { name } ... on StixCyberObservable { observable_value } }
+        to { ... on BasicObject { id entity_type } ... on StixDomainObject { name } ... on StixCyberObservable { observable_value } }
+      }
+    }
+  }
+}
+"""
+
+LABELS_QUERY = """
+query Labels {
+  labels { edges { node { id value color } } }
+}
+"""
+
+MARKING_DEFINITIONS_QUERY = """
+query MarkingDefinitions {
+  markingDefinitions { edges { node { id definition definition_type } } }
+}
+"""
+
+ORGANIZATIONS_QUERY = """
+query Organizations($first: Int) {
+  organizations(first: $first) {
+    edges {
+      node {
+        id
+        name
+        description
+      }
+    }
+  }
+}
+"""
+
 
 class Opencti():
 
@@ -87,12 +152,21 @@ class Opencti():
             raise Exception(f"GraphQL error: {data['errors'][0].get('message', 'Unknown error')}")
         return data.get("data", {})
 
+    def _get_connection(self, connection_params: dict):
+        base_url = connection_params['base_url'].rstrip('/')
+        api_token = connection_params['api_token']
+        headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+        return base_url, headers
+
+    def _parse_limit(self, raw_limit, default=25):
+        try:
+            return max(1, min(int(raw_limit), 100))
+        except (ValueError, TypeError):
+            return default
+
     def test_connection(self, connectionParameters: dict):
         try:
-            base_url = connectionParameters['base_url'].rstrip('/')
-            api_token = connectionParameters['api_token']
-            headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
-
+            base_url, headers = self._get_connection(connectionParameters)
             self._graphql_request(base_url, headers, "{ about { version } }", {})
             return {'status': 'success', 'message': 'Connected to OpenCTI successfully.'}
         except requests.exceptions.ConnectionError:
@@ -105,9 +179,7 @@ class Opencti():
 
     def lookup_observable(self, request: RequestBody) -> ResponseBody:
         try:
-            base_url = request.connectionParameters['base_url'].rstrip('/')
-            api_token = request.connectionParameters['api_token']
-            headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+            base_url, headers = self._get_connection(request.connectionParameters)
 
             observables = request.parameters["observables"]
             if isinstance(observables, str):
@@ -130,18 +202,8 @@ class Opencti():
                 filters = {
                     "mode": "and",
                     "filters": [
-                        {
-                            "key": ["entity_type"],
-                            "values": [observable_type],
-                            "operator": "eq",
-                            "mode": "or"
-                        },
-                        {
-                            "key": ["observable_value"],
-                            "values": [obs],
-                            "operator": "eq",
-                            "mode": "or"
-                        }
+                        {"key": ["entity_type"], "values": [observable_type], "operator": "eq", "mode": "or"},
+                        {"key": ["observable_value"], "values": [obs], "operator": "eq", "mode": "or"}
                     ],
                     "filterGroups": []
                 }
@@ -164,9 +226,7 @@ class Opencti():
 
     def get_indicator_details(self, request: RequestBody) -> ResponseBody:
         try:
-            base_url = request.connectionParameters['base_url'].rstrip('/')
-            api_token = request.connectionParameters['api_token']
-            headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+            base_url, headers = self._get_connection(request.connectionParameters)
 
             indicator_ids = request.parameters["indicator_ids"]
             if isinstance(indicator_ids, str):
@@ -197,20 +257,14 @@ class Opencti():
 
     def search_entities(self, request: RequestBody) -> ResponseBody:
         try:
-            base_url = request.connectionParameters['base_url'].rstrip('/')
-            api_token = request.connectionParameters['api_token']
-            headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+            base_url, headers = self._get_connection(request.connectionParameters)
 
             search_term = request.parameters["search_term"]
             if not search_term or not search_term.strip():
                 raise Exception("search_term is required and cannot be empty.")
 
             entity_type = request.parameters.get("entity_type")
-            limit = request.parameters.get("limit", "25")
-            try:
-                limit = max(1, min(int(limit), 100))
-            except (ValueError, TypeError):
-                limit = 25
+            limit = self._parse_limit(request.parameters.get("limit", "25"))
 
             variables = {"search": search_term.strip(), "first": limit}
             if entity_type and entity_type.strip():
@@ -226,4 +280,118 @@ class Opencti():
             raise Exception("Connection to OpenCTI timed out.")
         except Exception as e:
             self.logger.error("error while running action 'search_entities'", exc_info=e)
+            raise Exception(str(e))
+
+    def get_indicators(self, request: RequestBody) -> ResponseBody:
+        try:
+            base_url, headers = self._get_connection(request.connectionParameters)
+
+            search = request.parameters.get("search")
+            labels = request.parameters.get("labels")
+            confidence = request.parameters.get("confidence")
+            indicator_type = request.parameters.get("indicator_type")
+            limit = self._parse_limit(request.parameters.get("limit", "25"))
+
+            filters_list = []
+            if labels:
+                label_values = [l.strip() for l in labels.split(",")] if isinstance(labels, str) else labels
+                filters_list.append({"key": ["objectLabel"], "values": label_values, "operator": "eq", "mode": "or"})
+            if confidence:
+                filters_list.append({"key": ["confidence"], "values": [str(confidence)], "operator": "gte", "mode": "or"})
+            if indicator_type:
+                filters_list.append({"key": ["pattern_type"], "values": [indicator_type.strip()], "operator": "eq", "mode": "or"})
+
+            variables = {"first": limit}
+            if search and search.strip():
+                variables["search"] = search.strip()
+            if filters_list:
+                variables["filters"] = {"mode": "and", "filters": filters_list, "filterGroups": []}
+
+            data = self._graphql_request(base_url, headers, INDICATORS_QUERY, variables)
+            edges = data.get("indicators", {}).get("edges", [])
+
+            return {"status": "success", "results": [e["node"] for e in edges]}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to OpenCTI. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to OpenCTI timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'get_indicators'", exc_info=e)
+            raise Exception(str(e))
+
+    def get_relationships(self, request: RequestBody) -> ResponseBody:
+        try:
+            base_url, headers = self._get_connection(request.connectionParameters)
+
+            entity_id = request.parameters.get("entity_id")
+            if not entity_id or not entity_id.strip():
+                raise Exception("entity_id is required and cannot be empty.")
+
+            relationship_type = request.parameters.get("relationship_type")
+            limit = self._parse_limit(request.parameters.get("limit", "25"))
+
+            filters_list = [
+                {"key": ["fromId", "toId"], "values": [entity_id.strip()], "operator": "eq", "mode": "or"}
+            ]
+            if relationship_type and relationship_type.strip():
+                filters_list.append({"key": ["relationship_type"], "values": [relationship_type.strip()], "operator": "eq", "mode": "or"})
+
+            variables = {
+                "first": limit,
+                "filters": {"mode": "and", "filters": filters_list, "filterGroups": []}
+            }
+
+            data = self._graphql_request(base_url, headers, RELATIONSHIPS_QUERY, variables)
+            edges = data.get("stixCoreRelationships", {}).get("edges", [])
+
+            return {"status": "success", "results": [e["node"] for e in edges]}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to OpenCTI. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to OpenCTI timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'get_relationships'", exc_info=e)
+            raise Exception(str(e))
+
+    def list_labels(self, request: RequestBody) -> ResponseBody:
+        try:
+            base_url, headers = self._get_connection(request.connectionParameters)
+            data = self._graphql_request(base_url, headers, LABELS_QUERY, {})
+            edges = data.get("labels", {}).get("edges", [])
+            return {"status": "success", "results": [e["node"] for e in edges]}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to OpenCTI. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to OpenCTI timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'list_labels'", exc_info=e)
+            raise Exception(str(e))
+
+    def list_marking_definitions(self, request: RequestBody) -> ResponseBody:
+        try:
+            base_url, headers = self._get_connection(request.connectionParameters)
+            data = self._graphql_request(base_url, headers, MARKING_DEFINITIONS_QUERY, {})
+            edges = data.get("markingDefinitions", {}).get("edges", [])
+            return {"status": "success", "results": [e["node"] for e in edges]}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to OpenCTI. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to OpenCTI timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'list_marking_definitions'", exc_info=e)
+            raise Exception(str(e))
+
+    def list_organizations(self, request: RequestBody) -> ResponseBody:
+        try:
+            base_url, headers = self._get_connection(request.connectionParameters)
+            limit = self._parse_limit(request.parameters.get("limit", "100"))
+            data = self._graphql_request(base_url, headers, ORGANIZATIONS_QUERY, {"first": limit})
+            edges = data.get("organizations", {}).get("edges", [])
+            return {"status": "success", "results": [e["node"] for e in edges]}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to OpenCTI. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to OpenCTI timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'list_organizations'", exc_info=e)
             raise Exception(str(e))

--- a/opencti/integration_definition.json
+++ b/opencti/integration_definition.json
@@ -22,7 +22,7 @@
       }
     ],
     "isMultiAuthentication": false,
-    "desc": "OpenCTI integration for IOC and observable enrichment. Supports observable lookups, indicator details retrieval, and entity search using the OpenCTI GraphQL API.",
+    "desc": "OpenCTI integration for IOC and observable enrichment. Supports observable lookups, indicator details retrieval, entity search, relationship mapping, and reference data listing using the OpenCTI GraphQL API.",
     "functions": [
       {
         "label": "Lookup Observable",
@@ -139,6 +139,199 @@
             "label": "Results",
             "name": "results",
             "desc": "Search results",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "Get Indicators",
+        "name": "get_indicators",
+        "type": "ThreatIntel",
+        "desc": "Search indicators by text, labels, confidence, or indicator type",
+        "sampleOutput": "",
+        "inParameters": [
+          {
+            "label": "Search",
+            "name": "search",
+            "desc": "Optional search text to filter indicators",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          },
+          {
+            "label": "Labels",
+            "name": "labels",
+            "desc": "Comma-separated labels to filter by",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          },
+          {
+            "label": "Confidence",
+            "name": "confidence",
+            "desc": "Minimum confidence score to filter by",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          },
+          {
+            "label": "Indicator Type",
+            "name": "indicator_type",
+            "desc": "Indicator pattern type filter (e.g., stix, yara, sigma)",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          },
+          {
+            "label": "Limit",
+            "name": "limit",
+            "desc": "Maximum number of results to return (default: 25)",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          }
+        ],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "Indicator search results",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "Get Relationships",
+        "name": "get_relationships",
+        "type": "ThreatIntel",
+        "desc": "Get relationships connected to an entity including source, target, and relationship type",
+        "sampleOutput": "",
+        "inParameters": [
+          {
+            "label": "Entity ID",
+            "name": "entity_id",
+            "desc": "OpenCTI entity ID to get relationships for",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          },
+          {
+            "label": "Relationship Type",
+            "name": "relationship_type",
+            "desc": "Optional relationship type filter (e.g., uses, targets, indicates)",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          },
+          {
+            "label": "Limit",
+            "name": "limit",
+            "desc": "Maximum number of results to return (default: 25)",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          }
+        ],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "Relationship results",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "List Labels",
+        "name": "list_labels",
+        "type": "ThreatIntel",
+        "desc": "List all labels defined in OpenCTI",
+        "sampleOutput": "",
+        "inParameters": [],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "List of labels with id, value, and color",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "List Marking Definitions",
+        "name": "list_marking_definitions",
+        "type": "ThreatIntel",
+        "desc": "List all marking definitions (TLP, PAP, etc.) in OpenCTI",
+        "sampleOutput": "",
+        "inParameters": [],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "List of marking definitions with id, definition, and definition_type",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "List Organizations",
+        "name": "list_organizations",
+        "type": "ThreatIntel",
+        "desc": "List organizations (identities) in OpenCTI",
+        "sampleOutput": "",
+        "inParameters": [
+          {
+            "label": "Limit",
+            "name": "limit",
+            "desc": "Maximum number of results to return (default: 100)",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          }
+        ],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "List of organizations with id, name, and description",
             "type": "String",
             "values": [],
             "isSecret": false,

--- a/opencti/integration_meta_schema.json
+++ b/opencti/integration_meta_schema.json
@@ -1,0 +1,270 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://securonix.com/connectorinfo.schema.json",
+    "title": "ConnectorInfo",
+    "description": "A ConnectorInfo from securonix integrations",
+    "type": "object",
+    "required": [
+        "name",
+        "label",
+        "type",
+        "native",
+        "testUrl",
+        "isLicensed",
+        "pathToLogo"
+    ],
+    "properties": {
+        "desc": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "name": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "type": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "clazz": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "label": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "native": {
+            "description": "The unique identifier for a product",
+            "type": "boolean"
+        },
+        "testUrl": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "category": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "isLicensed": {
+            "description": "The unique identifier for a product",
+            "type": "boolean"
+        },
+        "pathToLogo": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "encodedLogo": {
+            "description": "The unique identifier for a product",
+            "type": "string"
+        },
+        "isMultiAuthentication": {
+            "description": "The unique identifier for a product",
+            "type": "boolean"
+        },
+        "connectionParameters": {
+            "description": "The unique identifier for a product",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "type",
+                    "label",
+                    "nested",
+                    "isSecret",
+                    "encrypted"
+                ],
+                "properties": {
+                    "desc": {
+                        "description": "The unique identifier for a product",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "The unique identifier for a product",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "The unique identifier for a product",
+                        "type": "string"
+                    },
+                    "label": {
+                        "description": "The unique identifier for a product",
+                        "type": "string"
+                    },
+                    "nested": {
+                        "description": "The unique identifier for a product",
+                        "type": "boolean"
+                    },
+                    "values": {
+                        "description": "The unique identifier for a product",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "isSecret": {
+                        "description": "The unique identifier for a product",
+                        "type": "boolean"
+                    },
+                    "optional": {
+                        "description": "The unique identifier for a product",
+                        "type": "boolean"
+                    },
+                    "encrypted": {
+                        "description": "The unique identifier for a product",
+                        "type": "boolean"
+                    },
+                    "contextEnrichment": {
+                        "description": "The unique identifier for a product",
+                        "type": "boolean"
+                    }
+                },
+                "minItems": 1,
+                "uniqueItems": true
+            },
+            "functions": {
+                "description": "The unique identifier for a product",
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "type",
+                        "label"
+                    ],
+                    "properties": {
+                        "desc": {
+                            "description": "The unique identifier for a product",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "The unique identifier for a product",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "The unique identifier for a product",
+                            "type": "string"
+                        },
+                        "label": {
+                            "description": "The unique identifier for a product",
+                            "type": "string"
+                        },
+                        "inParameters": {
+                            "description": "The unique identifier for a product",
+                            "type": "array",
+                            "items": {
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "type": "object",
+                                "properties": {
+                                    "desc": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "nested": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "values": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "isSecret": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "optional": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "encrypted": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "contextEnrichment": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        },
+                        "sampleOutput": {
+                            "description": "The unique identifier for a product",
+                            "type": "string"
+                        },
+                        "outParameters": {
+                            "description": "The unique identifier for a product",
+                            "type": "array",
+                            "items": {
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "type": "object",
+                                "properties": {
+                                    "desc": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "string"
+                                    },
+                                    "nested": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "values": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "isSecret": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "optional": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "encrypted": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    },
+                                    "contextEnrichment": {
+                                        "description": "The unique identifier for a product",
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "minItems": 1,
+                "uniqueItems": true
+            }
+        }
+    }
+}

--- a/opencti/tests/test_opencti.py
+++ b/opencti/tests/test_opencti.py
@@ -269,6 +269,175 @@ def test_search_entities_with_limit(mock_post):
     assert call_body["variables"]["first"] == 10
 
 
+# --- Get Indicators ---
+
+@patch("requests.post")
+def test_get_indicators_success(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "indicators": {
+            "edges": [{
+                "node": {
+                    "id": "ind-1",
+                    "name": "Malicious Domain",
+                    "pattern": "[domain-name:value = 'evil.com']",
+                    "pattern_type": "stix",
+                    "confidence": 90,
+                    "valid_from": "2024-01-01T00:00:00Z",
+                    "valid_until": "2025-01-01T00:00:00Z",
+                    "objectLabel": [{"value": "malicious"}],
+                    "objectMarking": [],
+                    "createdBy": {"name": "MITRE"}
+                }
+            }]
+        }
+    })
+    req = create_request_body({"search": "evil"})
+    resp = integration_class.get_indicators(req)
+    assert resp["status"] == "success"
+    assert len(resp["results"]) == 1
+    assert resp["results"][0]["name"] == "Malicious Domain"
+
+
+@patch("requests.post")
+def test_get_indicators_with_filters(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "indicators": {"edges": []}
+    })
+    req = create_request_body({"labels": "malicious,apt", "confidence": "80", "indicator_type": "stix", "limit": "10"})
+    resp = integration_class.get_indicators(req)
+    assert resp["status"] == "success"
+    call_body = mock_post.call_args[1]["json"]
+    assert call_body["variables"]["first"] == 10
+    assert "filters" in call_body["variables"]
+
+
+@patch("requests.post")
+def test_get_indicators_no_params(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "indicators": {"edges": []}
+    })
+    req = create_request_body({})
+    resp = integration_class.get_indicators(req)
+    assert resp["status"] == "success"
+    assert resp["results"] == []
+
+
+# --- Get Relationships ---
+
+@patch("requests.post")
+def test_get_relationships_success(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "stixCoreRelationships": {
+            "edges": [{
+                "node": {
+                    "id": "rel-1",
+                    "relationship_type": "uses",
+                    "start_time": "2024-01-01T00:00:00Z",
+                    "stop_time": None,
+                    "confidence": 75,
+                    "from": {"id": "entity-1", "entity_type": "Threat-Actor", "name": "APT28"},
+                    "to": {"id": "entity-2", "entity_type": "Malware", "name": "X-Agent"}
+                }
+            }]
+        }
+    })
+    req = create_request_body({"entity_id": "entity-1"})
+    resp = integration_class.get_relationships(req)
+    assert resp["status"] == "success"
+    assert len(resp["results"]) == 1
+    assert resp["results"][0]["relationship_type"] == "uses"
+
+
+@patch("requests.post")
+def test_get_relationships_with_type_filter(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "stixCoreRelationships": {"edges": []}
+    })
+    req = create_request_body({"entity_id": "entity-1", "relationship_type": "targets", "limit": "5"})
+    resp = integration_class.get_relationships(req)
+    assert resp["status"] == "success"
+    call_body = mock_post.call_args[1]["json"]
+    assert call_body["variables"]["first"] == 5
+
+
+def test_get_relationships_empty_entity_id():
+    req = create_request_body({"entity_id": ""})
+    try:
+        integration_class.get_relationships(req)
+        assert False, "Should have raised exception"
+    except Exception as e:
+        assert "entity_id is required" in str(e)
+
+
+# --- List Labels ---
+
+@patch("requests.post")
+def test_list_labels_success(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "labels": {
+            "edges": [
+                {"node": {"id": "lbl-1", "value": "malicious", "color": "#ff0000"}},
+                {"node": {"id": "lbl-2", "value": "benign", "color": "#00ff00"}}
+            ]
+        }
+    })
+    req = create_request_body({})
+    resp = integration_class.list_labels(req)
+    assert resp["status"] == "success"
+    assert len(resp["results"]) == 2
+    assert resp["results"][0]["value"] == "malicious"
+
+
+# --- List Marking Definitions ---
+
+@patch("requests.post")
+def test_list_marking_definitions_success(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "markingDefinitions": {
+            "edges": [
+                {"node": {"id": "marking-1", "definition": "TLP:WHITE", "definition_type": "TLP"}},
+                {"node": {"id": "marking-2", "definition": "TLP:RED", "definition_type": "TLP"}}
+            ]
+        }
+    })
+    req = create_request_body({})
+    resp = integration_class.list_marking_definitions(req)
+    assert resp["status"] == "success"
+    assert len(resp["results"]) == 2
+    assert resp["results"][1]["definition"] == "TLP:RED"
+
+
+# --- List Organizations ---
+
+@patch("requests.post")
+def test_list_organizations_success(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "organizations": {
+            "edges": [
+                {"node": {"id": "org-1", "name": "MITRE", "description": "Threat research org"}},
+                {"node": {"id": "org-2", "name": "CISA", "description": "US cybersecurity agency"}}
+            ]
+        }
+    })
+    req = create_request_body({})
+    resp = integration_class.list_organizations(req)
+    assert resp["status"] == "success"
+    assert len(resp["results"]) == 2
+    assert resp["results"][0]["name"] == "MITRE"
+
+
+@patch("requests.post")
+def test_list_organizations_with_limit(mock_post):
+    mock_post.return_value = mock_graphql_response({
+        "organizations": {"edges": []}
+    })
+    req = create_request_body({"limit": "5"})
+    resp = integration_class.list_organizations(req)
+    assert resp["status"] == "success"
+    call_body = mock_post.call_args[1]["json"]
+    assert call_body["variables"]["first"] == 5
+
+
 # --- Connection Parameter Validation ---
 
 def test_missing_base_url():


### PR DESCRIPTION
Adds 5 new read-only actions to the OpenCTI connector for threat intelligence enrichment and investigation in SOAR playbooks.
New Actions:
*  get_indicators — Search indicators by text, labels, confidence, or pattern type
*  get_relationships — Get relationships connected to an entity
*  list_labels — List all labels defined in OpenCTI
*  list_marking_definitions — List all marking definitions (TLP, PAP, etc.)
*  list_organizations — List all organizations/identities
Changes:
*  opencti/app/opencti.py — Added 5 new action methods + helper methods for code reuse
*  opencti/integration_definition.json — Added action definitions with input/output parameters
*  opencti/tests/test_opencti.py — Added 10 new unit tests (33 total, all passing)
*  opencti/integration_meta_schema.json — Added missing schema file