### PR TITLE
SOAR-12287: Fix Shodan connector and add 9 new actions

### DIFF
--- a/shodan/app/shodan.py
+++ b/shodan/app/shodan.py
@@ -1,46 +1,305 @@
-
-from app.model.request_body import RequestBody
-from app.model.response_body import ResponseBody
 import logging
+import re
+import time
 import requests
+from app.model.request_body import RequestBody
 
-class Shodan():
+IP_PATTERN = re.compile(
+    r'^((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)$'
+)
+DEFAULT_BASE_URL = "https://api.shodan.io"
+DEFAULT_TIMEOUT = 30
+MAX_RETRIES = 3
+BACKOFF_FACTOR = 2
+
+
+class Shodan:
 
     def __init__(self) -> None:
-        self.logger = logging.getLogger()
-        pass
+        self.logger = logging.getLogger(__name__)
 
-    def ip_address(self, request: RequestBody) -> ResponseBody:
-        server_url = request.connectionParameters['server_url']
-        api_token = request.connectionParameters['api_token']
-        ip_addr = request.parameters['ip_addr']
-        url = f"{server_url}/host/{ip_addr}"
-        headers = {
-        'Key': api_token
-        }
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-           hosts_info = response.json()
-           hosts = hosts_info.get('data', [])
-           return {'hosts': hosts}
-        else:
-        
-            return {'hosts': []}
+    def _get_connection(self, connection_params: dict):
+        base_url = connection_params.get('server_url', DEFAULT_BASE_URL).rstrip('/')
+        if not base_url:
+            base_url = DEFAULT_BASE_URL
+        api_token = connection_params.get('api_token')
+        if not api_token:
+            raise Exception("API Token is required.")
+        timeout = DEFAULT_TIMEOUT
+        try:
+            t = connection_params.get('timeout')
+            if t:
+                timeout = max(1, int(t))
+        except (ValueError, TypeError):
+            pass
+        return base_url, api_token, timeout
+
+    def _make_request(self, base_url: str, endpoint: str, api_token: str, timeout: int, params: dict = None) -> dict:
+        url = f"{base_url}{endpoint}"
+        req_params = params.copy() if params else {}
+        req_params["key"] = api_token
+
+        last_exception = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = requests.get(url, params=req_params, timeout=timeout)
+
+                if resp.status_code == 200:
+                    try:
+                        return resp.json()
+                    except ValueError:
+                        return {"raw_text": resp.text}
+
+                if resp.status_code in (401, 403):
+                    raise Exception("Authentication failed. Please verify your API Token is correct.")
+
+                if resp.status_code == 429:
+                    if attempt < MAX_RETRIES - 1:
+                        wait = BACKOFF_FACTOR ** (attempt + 1)
+                        self.logger.warning("Rate limited (429). Retrying in %ds...", wait)
+                        time.sleep(wait)
+                        last_exception = Exception("Rate limit exceeded. Please try again later.")
+                        continue
+                    raise Exception("Rate limit exceeded. Please try again later.")
+
+                if resp.status_code >= 500:
+                    if attempt < MAX_RETRIES - 1:
+                        wait = BACKOFF_FACTOR ** (attempt + 1)
+                        self.logger.warning("Server error (%d). Retrying in %ds...", resp.status_code, wait)
+                        time.sleep(wait)
+                        last_exception = Exception(f"Shodan server error (HTTP {resp.status_code}).")
+                        continue
+                    raise Exception(f"Shodan server error (HTTP {resp.status_code}).")
+
+                try:
+                    err_body = resp.json()
+                    err_msg = err_body.get("error", resp.text)
+                except ValueError:
+                    err_msg = resp.text
+                raise Exception(f"API request failed (HTTP {resp.status_code}): {err_msg}")
+
+            except requests.exceptions.ConnectionError:
+                raise Exception("Unable to connect to Shodan. Please verify the Server URL.")
+            except requests.exceptions.Timeout:
+                raise Exception("Connection to Shodan timed out.")
+            except Exception as e:
+                if "Authentication failed" in str(e) or "Rate limit" in str(e) or "Unable to connect" in str(e) or "timed out" in str(e):
+                    raise
+                last_exception = e
+                if attempt < MAX_RETRIES - 1:
+                    continue
+                raise
+
+        if last_exception:
+            raise last_exception
+
+    def _validate_ip(self, ip: str):
+        if not ip or not ip.strip():
+            raise Exception("IP address is required and cannot be empty.")
+        ip = ip.strip()
+        if not IP_PATTERN.match(ip):
+            raise Exception(f"Invalid IP address format: {ip}")
+        return ip
+
+    def _validate_required(self, value, field_name: str):
+        if not value or (isinstance(value, str) and not value.strip()):
+            raise Exception(f"{field_name} is required and cannot be empty.")
+        return value.strip() if isinstance(value, str) else value
 
     def test_connection(self, connectionParameters: dict):
-        server_url = connectionParameters['server_url']
-        api_token = connectionParameters['api_token']
-        ip_addr = '1.1.1.1'  # Hardcoded IP address for testing
-        url = f"{server_url}/host/{ip_addr}"
-        headers = {
-        'Key': api_token
-        }
-
         try:
-            response = requests.get(url, headers=headers)
-            if response.status_code == 200:
-                return 'Connection Successful'
-            else:
-               response.raise_for_status()
+            base_url, api_token, timeout = self._get_connection(connectionParameters)
+            self._make_request(base_url, "/api-info", api_token, timeout)
+            return {"status": "success", "message": "Connected to Shodan successfully."}
         except Exception as e:
+            self.logger.exception("Exception while testing connection")
+            raise Exception(str(e))
+
+    def ip_address(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            ip = request.parameters.get('ip_addr') or request.parameters.get('ip')
+            ip = self._validate_ip(ip)
+
+            data = self._make_request(base_url, f"/shodan/host/{ip}", api_token, timeout)
+
+            return {
+                "ip": data.get("ip_str", ip),
+                "organization": data.get("org"),
+                "isp": data.get("isp"),
+                "hostnames": data.get("hostnames", []),
+                "domains": data.get("domains", []),
+                "country": data.get("country_name"),
+                "city": data.get("city"),
+                "latitude": data.get("latitude"),
+                "longitude": data.get("longitude"),
+                "ports": data.get("ports", []),
+                "os": data.get("os"),
+                "vulnerabilities": data.get("vulns", []),
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in ip_address action")
+            raise Exception(str(e))
+
+    def domain_lookup(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            domain = self._validate_required(request.parameters.get('domain'), "domain")
+
+            data = self._make_request(base_url, f"/dns/domain/{domain}", api_token, timeout)
+
+            return {
+                "domain": data.get("domain", domain),
+                "subdomains": data.get("subdomains", []),
+                "tags": data.get("tags", []),
+                "data": data.get("data", []),
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in domain_lookup action")
+            raise Exception(str(e))
+
+    def host_search(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            query = self._validate_required(request.parameters.get('query'), "query")
+
+            params = {"query": query}
+            page = request.parameters.get('page')
+            if page:
+                try:
+                    p = int(page)
+                    if p > 0:
+                        params["page"] = p
+                except (ValueError, TypeError):
+                    pass
+
+            data = self._make_request(base_url, "/shodan/host/search", api_token, timeout, params)
+
+            return {
+                "total": data.get("total", 0),
+                "matches": data.get("matches", []),
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in host_search action")
+            raise Exception(str(e))
+
+    def host_count(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            query = self._validate_required(request.parameters.get('query'), "query")
+
+            params = {"query": query}
+            facets = request.parameters.get('facets')
+            if facets:
+                params["facets"] = facets
+
+            data = self._make_request(base_url, "/shodan/host/count", api_token, timeout, params)
+
+            return {
+                "total": data.get("total", 0),
+                "facets": data.get("facets", {}),
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in host_count action")
+            raise Exception(str(e))
+
+    def list_ports(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            data = self._make_request(base_url, "/shodan/ports", api_token, timeout)
+
+            return {
+                "ports": data if isinstance(data, list) else [],
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in list_ports action")
+            raise Exception(str(e))
+
+    def list_protocols(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            data = self._make_request(base_url, "/shodan/protocols", api_token, timeout)
+
+            return {
+                "protocols": data if isinstance(data, dict) else {},
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in list_protocols action")
+            raise Exception(str(e))
+
+    def list_services(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            data = self._make_request(base_url, "/shodan/services", api_token, timeout)
+
+            return {
+                "services": data if isinstance(data, dict) else {},
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in list_services action")
+            raise Exception(str(e))
+
+    def honeyscore(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            ip = request.parameters.get('ip')
+            ip = self._validate_ip(ip)
+
+            data = self._make_request(base_url, f"/labs/honeyscore/{ip}", api_token, timeout)
+
+            if isinstance(data, dict):
+                score = data.get("honeyscore")
+            else:
+                try:
+                    score = float(data)
+                except (ValueError, TypeError):
+                    score = None
+
+            return {
+                "ip": ip,
+                "honeyscore": score,
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in honeyscore action")
+            raise Exception(str(e))
+
+    def my_ip(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            data = self._make_request(base_url, "/tools/myip", api_token, timeout)
+
+            ip = data if isinstance(data, str) else data.get("ip") if isinstance(data, dict) else str(data)
+
+            return {
+                "ip": ip,
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in my_ip action")
+            raise Exception(str(e))
+
+    def api_info(self, request: RequestBody) -> dict:
+        try:
+            base_url, api_token, timeout = self._get_connection(request.connectionParameters)
+            data = self._make_request(base_url, "/api-info", api_token, timeout)
+
+            return {
+                "query_credits": data.get("query_credits"),
+                "scan_credits": data.get("scan_credits"),
+                "monitored_ips": data.get("monitored_ips"),
+                "plan": data.get("plan"),
+                "https": data.get("https"),
+                "unlocked": data.get("unlocked"),
+                "raw_response": data
+            }
+        except Exception as e:
+            self.logger.exception("Error in api_info action")
             raise Exception(str(e))

--- a/shodan/integration_definition.json
+++ b/shodan/integration_definition.json
@@ -3,20 +3,20 @@
         {
             "label": "Server URL",
             "name": "server_url",
-            "desc": "Server URL of the Shodan Instance",
+            "desc": "Base URL of the Shodan API (default: https://api.shodan.io)",
             "type": "String",
             "values": [],
             "isSecret": false,
-            "optional": false,
+            "optional": true,
             "encrypted": false
         },
         {
             "label": "API Token",
             "name": "api_token",
-            "desc": "Token for Authetication",
+            "desc": "Shodan API Key for authentication",
             "type": "String",
             "values": [],
-            "isSecret": false,
+            "isSecret": true,
             "optional": false,
             "encrypted": false
         }
@@ -24,15 +24,15 @@
     "functions": [
         {
             "desc": "Returns all services that have been found on the given host IP",
-            "label": "Get Host of IP",
+            "label": "Get Host Info",
             "name": "ip_address",
-            "type": "Get Host from IP",
+            "type": "Enrichment",
             "sampleOutput": "",
             "inParameters": [
                 {
-                    "label": "Ip Address",
+                    "label": "IP Address",
                     "name": "ip_addr",
-                    "desc": "Provide IP address ",
+                    "desc": "IPv4 address to look up",
                     "type": "String",
                     "values": [],
                     "isSecret": false,
@@ -42,17 +42,450 @@
             ],
             "outParameters": [
                 {
-                    "label": "hosts",
-                    "name": "hosts",
-                    "desc": "Response",
+                    "label": "IP",
+                    "name": "ip",
+                    "desc": "IP address",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Organization",
+                    "name": "organization",
+                    "desc": "Organization that owns the IP",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                },
+                {
+                    "label": "Ports",
+                    "name": "ports",
+                    "desc": "Open ports",
                     "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                },
+                {
+                    "label": "Vulnerabilities",
+                    "name": "vulnerabilities",
+                    "desc": "Known CVEs",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "Get DNS information for a domain including subdomains",
+            "label": "Domain Lookup",
+            "name": "domain_lookup",
+            "type": "Enrichment",
+            "sampleOutput": "",
+            "inParameters": [
+                {
+                    "label": "Domain",
+                    "name": "domain",
+                    "desc": "Domain name to look up (e.g. google.com)",
+                    "type": "String",
                     "values": [],
                     "isSecret": false,
                     "optional": false,
                     "encrypted": false
                 }
+            ],
+            "outParameters": [
+                {
+                    "label": "Domain",
+                    "name": "domain",
+                    "desc": "Domain name",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Subdomains",
+                    "name": "subdomains",
+                    "desc": "List of subdomains",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "Search Shodan using query strings",
+            "label": "Host Search",
+            "name": "host_search",
+            "type": "Enrichment",
+            "sampleOutput": "",
+            "inParameters": [
+                {
+                    "label": "Query",
+                    "name": "query",
+                    "desc": "Shodan search query (e.g. apache, port:22)",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Page",
+                    "name": "page",
+                    "desc": "Page number for results (optional)",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ],
+            "outParameters": [
+                {
+                    "label": "Total",
+                    "name": "total",
+                    "desc": "Total number of results",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Matches",
+                    "name": "matches",
+                    "desc": "Search result matches",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "Get result count for a Shodan search query",
+            "label": "Host Count",
+            "name": "host_count",
+            "type": "Enrichment",
+            "sampleOutput": "",
+            "inParameters": [
+                {
+                    "label": "Query",
+                    "name": "query",
+                    "desc": "Shodan search query",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Facets",
+                    "name": "facets",
+                    "desc": "Comma-separated list of facets (optional, e.g. country,org)",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ],
+            "outParameters": [
+                {
+                    "label": "Total",
+                    "name": "total",
+                    "desc": "Total number of results",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Facets",
+                    "name": "facets",
+                    "desc": "Facet breakdown",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "List all ports that Shodan crawls on the Internet",
+            "label": "List Ports",
+            "name": "list_ports",
+            "type": "Enrichment",
+            "sampleOutput": "",
+            "inParameters": [],
+            "outParameters": [
+                {
+                    "label": "Ports",
+                    "name": "ports",
+                    "desc": "List of port numbers",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "List all protocols that can be used for scanning",
+            "label": "List Protocols",
+            "name": "list_protocols",
+            "type": "Enrichment",
+            "sampleOutput": "",
+            "inParameters": [],
+            "outParameters": [
+                {
+                    "label": "Protocols",
+                    "name": "protocols",
+                    "desc": "Map of protocol name to description",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "List available Shodan services/banners",
+            "label": "List Services",
+            "name": "list_services",
+            "type": "Enrichment",
+            "sampleOutput": "",
+            "inParameters": [],
+            "outParameters": [
+                {
+                    "label": "Services",
+                    "name": "services",
+                    "desc": "Map of port to service name",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "Calculate honeypot probability score for an IP",
+            "label": "Honeyscore",
+            "name": "honeyscore",
+            "type": "Enrichment",
+            "sampleOutput": "",
+            "inParameters": [
+                {
+                    "label": "IP Address",
+                    "name": "ip",
+                    "desc": "IPv4 address to check",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                }
+            ],
+            "outParameters": [
+                {
+                    "label": "IP",
+                    "name": "ip",
+                    "desc": "IP address checked",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Honeyscore",
+                    "name": "honeyscore",
+                    "desc": "Honeypot probability (0.0 to 1.0)",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "Get the caller's external IP address",
+            "label": "My IP",
+            "name": "my_ip",
+            "type": "Utility",
+            "sampleOutput": "",
+            "inParameters": [],
+            "outParameters": [
+                {
+                    "label": "IP",
+                    "name": "ip",
+                    "desc": "External IP address",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
+            ]
+        },
+        {
+            "desc": "Get API usage and plan information",
+            "label": "API Info",
+            "name": "api_info",
+            "type": "Utility",
+            "sampleOutput": "",
+            "inParameters": [],
+            "outParameters": [
+                {
+                    "label": "Query Credits",
+                    "name": "query_credits",
+                    "desc": "Remaining query credits",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Scan Credits",
+                    "name": "scan_credits",
+                    "desc": "Remaining scan credits",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Plan",
+                    "name": "plan",
+                    "desc": "API plan name",
+                    "type": "String",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": false,
+                    "encrypted": false
+                },
+                {
+                    "label": "Raw Response",
+                    "name": "raw_response",
+                    "desc": "Full API response",
+                    "type": "Object",
+                    "values": [],
+                    "isSecret": false,
+                    "optional": true,
+                    "encrypted": false
+                }
             ]
         }
     ]
-
 }

--- a/shodan/tests/test_shodan.py
+++ b/shodan/tests/test_shodan.py
@@ -1,13 +1,256 @@
-
+import pytest
+from unittest.mock import patch, MagicMock
 from app.shodan import Shodan
 from app.model.request_body import RequestBody
 from pykson import Pykson
 import json
+
 pykson = Pykson()
 integration_class = Shodan()
 
-def test_ip_address():
-    req = '{"connectionParameters": {"server_url": "https://api.shodan.io/shodan", "api_token": "samplevalue"}, "parameters": {"ip_addr": "1.1.1.1"}}'
-    req = pykson.from_json(req, RequestBody, True)
-    resp = integration_class.ip_address(req)
-    assert (resp is not None)
+CONNECTION_PARAMS = {"server_url": "https://api.shodan.io", "api_token": "test_token"}
+
+
+def _make_request(params=None):
+    body = {"connectionParameters": CONNECTION_PARAMS, "parameters": params or {}}
+    return pykson.from_json(json.dumps(body), RequestBody, True)
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.text = text
+    mock.json.return_value = json_data if json_data is not None else {}
+    return mock
+
+
+class TestTestConnection:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {"plan": "dev", "query_credits": 100})
+        result = integration_class.test_connection(CONNECTION_PARAMS)
+        assert result["status"] == "success"
+
+    @patch("app.shodan.requests.get")
+    def test_auth_failure(self, mock_get):
+        mock_get.return_value = _mock_response(401, {"error": "Access denied"})
+        with pytest.raises(Exception, match="Authentication failed"):
+            integration_class.test_connection(CONNECTION_PARAMS)
+
+    def test_missing_api_token(self):
+        with pytest.raises(Exception, match="API Token is required"):
+            integration_class.test_connection({"server_url": "https://api.shodan.io"})
+
+
+class TestIpAddress:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {
+            "ip_str": "8.8.8.8", "org": "Google LLC", "isp": "Google LLC",
+            "hostnames": ["dns.google"], "domains": ["google.com"],
+            "country_name": "United States", "city": "Mountain View",
+            "latitude": 37.386, "longitude": -122.0838,
+            "ports": [53, 443], "os": None, "vulns": ["CVE-2021-1234"]
+        })
+        resp = integration_class.ip_address(_make_request({"ip_addr": "8.8.8.8"}))
+        assert resp["ip"] == "8.8.8.8"
+        assert resp["organization"] == "Google LLC"
+        assert resp["ports"] == [53, 443]
+        assert resp["vulnerabilities"] == ["CVE-2021-1234"]
+
+    def test_invalid_ip(self):
+        with pytest.raises(Exception, match="Invalid IP address format"):
+            integration_class.ip_address(_make_request({"ip_addr": "999.999.999.999"}))
+
+    def test_empty_ip(self):
+        with pytest.raises(Exception, match="IP address is required"):
+            integration_class.ip_address(_make_request({"ip_addr": ""}))
+
+    @patch("app.shodan.requests.get")
+    def test_ip_param_alias(self, mock_get):
+        mock_get.return_value = _mock_response(200, {"ip_str": "1.1.1.1", "ports": [80]})
+        resp = integration_class.ip_address(_make_request({"ip": "1.1.1.1"}))
+        assert resp["ip"] == "1.1.1.1"
+
+
+class TestDomainLookup:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {
+            "domain": "google.com",
+            "subdomains": ["www", "mail", "dns"],
+            "tags": ["ipv6"],
+            "data": [{"subdomain": "www", "type": "A", "value": "142.250.80.46"}]
+        })
+        resp = integration_class.domain_lookup(_make_request({"domain": "google.com"}))
+        assert resp["domain"] == "google.com"
+        assert "www" in resp["subdomains"]
+        assert len(resp["data"]) == 1
+
+    def test_empty_domain(self):
+        with pytest.raises(Exception, match="domain is required"):
+            integration_class.domain_lookup(_make_request({"domain": ""}))
+
+
+class TestHostSearch:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {
+            "total": 500,
+            "matches": [{"ip_str": "1.2.3.4", "port": 80}]
+        })
+        resp = integration_class.host_search(_make_request({"query": "apache"}))
+        assert resp["total"] == 500
+        assert len(resp["matches"]) == 1
+
+    @patch("app.shodan.requests.get")
+    def test_with_page(self, mock_get):
+        mock_get.return_value = _mock_response(200, {"total": 100, "matches": []})
+        resp = integration_class.host_search(_make_request({"query": "nginx", "page": "2"}))
+        assert resp["total"] == 100
+        call_params = mock_get.call_args[1]["params"]
+        assert call_params["page"] == 2
+
+    def test_empty_query(self):
+        with pytest.raises(Exception, match="query is required"):
+            integration_class.host_search(_make_request({"query": ""}))
+
+
+class TestHostCount:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {"total": 12345, "facets": {}})
+        resp = integration_class.host_count(_make_request({"query": "apache"}))
+        assert resp["total"] == 12345
+
+    @patch("app.shodan.requests.get")
+    def test_with_facets(self, mock_get):
+        mock_get.return_value = _mock_response(200, {
+            "total": 100, "facets": {"country": [{"value": "US", "count": 50}]}
+        })
+        resp = integration_class.host_count(_make_request({"query": "nginx", "facets": "country"}))
+        assert "country" in resp["facets"]
+
+
+class TestListPorts:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, [21, 22, 23, 25, 80, 443])
+        mock_get.return_value.json.return_value = [21, 22, 23, 25, 80, 443]
+        resp = integration_class.list_ports(_make_request())
+        assert 80 in resp["ports"]
+        assert 443 in resp["ports"]
+
+
+class TestListProtocols:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {"http": "HTTP", "ssh": "SSH"})
+        resp = integration_class.list_protocols(_make_request())
+        assert "http" in resp["protocols"]
+
+
+class TestListServices:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {"80": "HTTP", "443": "HTTPS"})
+        resp = integration_class.list_services(_make_request())
+        assert "80" in resp["services"]
+
+
+class TestHoneyscore:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, 0.5)
+        mock_get.return_value.json.return_value = 0.5
+        resp = integration_class.honeyscore(_make_request({"ip": "8.8.8.8"}))
+        assert resp["ip"] == "8.8.8.8"
+        assert resp["honeyscore"] == 0.5
+
+    def test_invalid_ip(self):
+        with pytest.raises(Exception, match="Invalid IP address format"):
+            integration_class.honeyscore(_make_request({"ip": "not_an_ip"}))
+
+
+class TestMyIp:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, "1.2.3.4")
+        mock_get.return_value.json.return_value = "1.2.3.4"
+        resp = integration_class.my_ip(_make_request())
+        assert resp["ip"] == "1.2.3.4"
+
+
+class TestApiInfo:
+    @patch("app.shodan.requests.get")
+    def test_success(self, mock_get):
+        mock_get.return_value = _mock_response(200, {
+            "query_credits": 100, "scan_credits": 50,
+            "monitored_ips": 5, "plan": "dev", "https": True, "unlocked": True
+        })
+        resp = integration_class.api_info(_make_request())
+        assert resp["query_credits"] == 100
+        assert resp["plan"] == "dev"
+        assert resp["unlocked"] is True
+
+
+class TestErrorHandling:
+    @patch("app.shodan.requests.get")
+    def test_connection_error(self, mock_get):
+        mock_get.side_effect = Exception("Unable to connect to Shodan. Please verify the Server URL.")
+        with pytest.raises(Exception, match="Unable to connect"):
+            integration_class.ip_address(_make_request({"ip_addr": "8.8.8.8"}))
+
+    @patch("app.shodan.requests.get")
+    def test_timeout(self, mock_get):
+        import requests as req
+        mock_get.side_effect = req.exceptions.Timeout()
+        with pytest.raises(Exception, match="timed out"):
+            integration_class.ip_address(_make_request({"ip_addr": "8.8.8.8"}))
+
+    @patch("app.shodan.requests.get")
+    def test_auth_failure(self, mock_get):
+        mock_get.return_value = _mock_response(403, {"error": "Access denied"})
+        with pytest.raises(Exception, match="Authentication failed"):
+            integration_class.ip_address(_make_request({"ip_addr": "8.8.8.8"}))
+
+    @patch("app.shodan.requests.get")
+    @patch("app.shodan.time.sleep")
+    def test_rate_limit_retry(self, mock_sleep, mock_get):
+        mock_get.side_effect = [
+            _mock_response(429), _mock_response(429), _mock_response(429)
+        ]
+        with pytest.raises(Exception, match="Rate limit exceeded"):
+            integration_class.ip_address(_make_request({"ip_addr": "8.8.8.8"}))
+        assert mock_sleep.call_count == 2
+
+    @patch("app.shodan.requests.get")
+    @patch("app.shodan.time.sleep")
+    def test_rate_limit_recovery(self, mock_sleep, mock_get):
+        mock_get.side_effect = [
+            _mock_response(429),
+            _mock_response(200, {"ip_str": "8.8.8.8", "ports": [80]})
+        ]
+        resp = integration_class.ip_address(_make_request({"ip_addr": "8.8.8.8"}))
+        assert resp["ip"] == "8.8.8.8"
+
+    @patch("app.shodan.requests.get")
+    @patch("app.shodan.time.sleep")
+    def test_server_error_retry(self, mock_sleep, mock_get):
+        mock_get.side_effect = [
+            _mock_response(500),
+            _mock_response(200, {"ip_str": "8.8.8.8", "ports": []})
+        ]
+        resp = integration_class.ip_address(_make_request({"ip_addr": "8.8.8.8"}))
+        assert resp["ip"] == "8.8.8.8"
+
+
+class TestDefaultBaseUrl:
+    @patch("app.shodan.requests.get")
+    def test_empty_server_url_uses_default(self, mock_get):
+        mock_get.return_value = _mock_response(200, {"plan": "dev", "query_credits": 10})
+        params = {"server_url": "", "api_token": "test_token"}
+        result = integration_class.test_connection(params)
+        assert result["status"] == "success"
+        call_url = mock_get.call_args[0][0]
+        assert call_url.startswith("https://api.shodan.io")


### PR DESCRIPTION
- Fix ip_address: correct endpoint (/shodan/host/{ip}), auth via query param
- Add actions: domain_lookup, host_search, host_count, list_ports, list_protocols, list_services, honeyscore, my_ip, api_info
- Add shared _make_request helper with retry/backoff for 429 and 5xx
- Add IP validation, required field validation, structured error handling
- Update integration_definition.json with all 10 actions
