### PR TITLE
fix(urlhaus): fix endpoint, auth, timeout, and reputation logic

### DIFF
--- a/urlhaus/app/urlhaus.py
+++ b/urlhaus/app/urlhaus.py
@@ -1,5 +1,4 @@
 from app.model.request_body import RequestBody
-from app.model.response_body import ResponseBody
 import logging
 import json
 import requests
@@ -9,34 +8,35 @@ class Urlhaus():
 
     def __init__(self) -> None:
         self.logger = logging.getLogger()
+        self.timeout = 30
 
-   # -------------------------------
+    # -------------------------------
     # Test Connection
     # -------------------------------
     def test_connection(self, connectionParameters: dict):
         base_url = connectionParameters['base_url'].rstrip('/')
-        auth_key = connectionParameters['auth_key']
+        api_key = connectionParameters.get('api_key', '')
+        headers = self._build_headers(api_key)
 
         try:
-            test_url = "https://example.com"
-
             resp = requests.post(
                 f"{base_url}/url/",
-                data={"url": test_url, "auth_key": auth_key}
+                headers=headers,
+                data={"url": "https://example.com"},
+                timeout=self.timeout
             )
             resp.raise_for_status()
-
             data = resp.json()
             self.logger.debug("URLhaus test_connection response: %s", json.dumps(data))
 
             if "query_status" in data:
-                return {
-                    "status": "success",
-                    "message": "Connected to URLhaus successfully."
-                }
+                return {"status": "success", "message": "Connected to URLhaus successfully."}
 
             raise Exception(f"Unexpected response from URLhaus: {data}")
-
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to URLhaus. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to URLhaus timed out.")
         except Exception as e:
             self.logger.error("Exception while testing URLhaus connection", exc_info=e)
             raise Exception(str(e))
@@ -44,118 +44,138 @@ class Urlhaus():
     # -------------------------------
     # Helpers
     # -------------------------------
+    def _build_headers(self, api_key):
+        headers = {}
+        if api_key:
+            headers["Auth-Key"] = api_key
+        return headers
+
     def _normalize_values(self, value):
         if isinstance(value, str):
-            return [v.strip() for v in value.split(",")]
+            return [v.strip() for v in value.split(",") if v.strip()]
         elif isinstance(value, list):
             return value
         else:
             raise Exception("Invalid input format")
 
-    def _lookup(self, base_url, endpoint, payload):
-        resp = requests.post(f"{base_url}/{endpoint}", data=payload)
-        resp.raise_for_status()
+    def _lookup(self, base_url, endpoint, payload, headers):
+        resp = requests.post(f"{base_url}/{endpoint}", headers=headers, data=payload, timeout=self.timeout)
+        if resp.status_code >= 400:
+            raise Exception(f"URLhaus API returned HTTP {resp.status_code}: {resp.text}")
         data = resp.json()
-
         self.logger.debug("URLhaus response from %s: %s", endpoint, json.dumps(data))
         return data
+
+    def _determine_reputation(self, data, entity_type="url"):
+        status = data.get("query_status")
+        if status == "no_results":
+            return "unknown"
+        if status != "ok":
+            return "error"
+        if entity_type == "url":
+            threat = data.get("threat")
+            url_status = data.get("url_status")
+            if threat and threat != "none":
+                return "malicious"
+            if url_status == "online":
+                return "malicious"
+            if url_status == "offline":
+                return "suspicious"
+            return "suspicious"
+        if entity_type == "host":
+            return "malicious" if data.get("url_count", 0) > 0 else "unknown"
+        if entity_type == "payload":
+            return "malicious"
+        return "unknown"
 
     # -------------------------------
     # Actions (Reputation Style)
     # -------------------------------
 
-    def url_reputation(self, request: RequestBody) -> ResponseBody:
+    def url_reputation(self, request: RequestBody) -> dict:
         base_url = request.connectionParameters['base_url'].rstrip('/')
-        auth_key = request.connectionParameters['auth_key']
+        api_key = request.connectionParameters.get('api_key', '')
+        headers = self._build_headers(api_key)
 
-        urls = self._normalize_values(request.parameters["urls"])
-        results = []
+        try:
+            urls = self._normalize_values(request.parameters["urls"])
+            results = []
 
-        for url in urls:
-            data = self._lookup(base_url, "url/", {"url": url, "auth_key": auth_key})
+            for url in urls:
+                data = self._lookup(base_url, "url/", {"url": url}, headers)
+                results.append({"url": url, "reputation": self._determine_reputation(data)})
 
-            if data.get("query_status") == "ok":
-                results.append({
-                    "url": url,
-                    "reputation": "malicious"
-                })
-            else:
-                results.append({
-                    "url": url,
-                    "reputation": "unknown"
-                })
+            return {"status": "success", "results": results}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to URLhaus. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to URLhaus timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'url_reputation'", exc_info=e)
+            raise Exception(str(e))
 
-        return {"status": "success", "results": results}
-
-    def host_reputation(self, request: RequestBody) -> ResponseBody:
+    def host_reputation(self, request: RequestBody) -> dict:
         base_url = request.connectionParameters['base_url'].rstrip('/')
-        auth_key = request.connectionParameters['auth_key']
+        api_key = request.connectionParameters.get('api_key', '')
+        headers = self._build_headers(api_key)
 
-        hosts = self._normalize_values(request.parameters["hosts"])
-        results = []
+        try:
+            hosts = self._normalize_values(request.parameters["hosts"])
+            results = []
 
-        for host in hosts:
-            data = self._lookup(base_url, "host/", {"host": host, "auth_key": auth_key})
+            for host in hosts:
+                data = self._lookup(base_url, "host/", {"host": host}, headers)
+                results.append({"host": host, "reputation": self._determine_reputation(data, "host")})
 
-            if data.get("query_status") == "ok":
-                results.append({
-                    "host": host,
-                    "reputation": "malicious"
-                })
-            else:
-                results.append({
-                    "host": host,
-                    "reputation": "unknown"
-                })
+            return {"status": "success", "results": results}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to URLhaus. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to URLhaus timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'host_reputation'", exc_info=e)
+            raise Exception(str(e))
 
-        return {"status": "success", "results": results}
-
-    def domain_reputation(self, request: RequestBody) -> ResponseBody:
+    def domain_reputation(self, request: RequestBody) -> dict:
         base_url = request.connectionParameters['base_url'].rstrip('/')
-        auth_key = request.connectionParameters['auth_key']
+        api_key = request.connectionParameters.get('api_key', '')
+        headers = self._build_headers(api_key)
 
-        domains = self._normalize_values(request.parameters["domains"])
-        results = []
+        try:
+            domains = self._normalize_values(request.parameters["domains"])
+            results = []
 
-        for domain in domains:
-            data = self._lookup(base_url, "domain/", {"domain": domain, "auth_key": auth_key})
+            for domain in domains:
+                data = self._lookup(base_url, "host/", {"host": domain}, headers)
+                results.append({"domain": domain, "reputation": self._determine_reputation(data, "host")})
 
-            if data.get("query_status") == "ok":
-                results.append({
-                    "domain": domain,
-                    "reputation": "malicious"
-                })
-            else:
-                results.append({
-                    "domain": domain,
-                    "reputation": "unknown"
-                })
+            return {"status": "success", "results": results}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to URLhaus. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to URLhaus timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'domain_reputation'", exc_info=e)
+            raise Exception(str(e))
 
-        return {"status": "success", "results": results}
-
-    def file_reputation(self, request: RequestBody) -> ResponseBody:
+    def file_reputation(self, request: RequestBody) -> dict:
         base_url = request.connectionParameters['base_url'].rstrip('/')
-        auth_key = request.connectionParameters['auth_key']
+        api_key = request.connectionParameters.get('api_key', '')
+        headers = self._build_headers(api_key)
 
-        hashes = self._normalize_values(request.parameters["sha256_hashes"])
-        results = []
+        try:
+            hashes = self._normalize_values(request.parameters["sha256_hashes"])
+            results = []
 
-        for file_hash in hashes:
-            data = self._lookup(
-                base_url,
-                "payload/",
-                {"sha256_hash": file_hash, "auth_key": auth_key}
-            )
+            for file_hash in hashes:
+                data = self._lookup(base_url, "payload/", {"sha256_hash": file_hash}, headers)
+                results.append({"sha256_hash": file_hash, "reputation": self._determine_reputation(data, "payload")})
 
-            if data.get("query_status") == "ok":
-                results.append({
-                    "sha256_hash": file_hash,
-                    "reputation": "malicious"
-                })
-            else:
-                results.append({
-                    "sha256_hash": file_hash,
-                    "reputation": "unknown"
-                })
-
-        return {"status": "success", "results": results}
+            return {"status": "success", "results": results}
+        except requests.exceptions.ConnectionError:
+            raise Exception("Unable to connect to URLhaus. Please verify the Base URL.")
+        except requests.exceptions.Timeout:
+            raise Exception("Connection to URLhaus timed out.")
+        except Exception as e:
+            self.logger.error("error while running action 'file_reputation'", exc_info=e)
+            raise Exception(str(e))

--- a/urlhaus/integration_definition.json
+++ b/urlhaus/integration_definition.json
@@ -13,11 +13,11 @@
     {
       "label": "API Key",
       "name": "api_key",
-      "desc": "Optional API key if required by the deployment or proxy layer",
+      "desc": "Optional Auth-Key for URLhaus API (sent as Auth-Key header)",
       "type": "String",
       "values": [],
       "isSecret": true,
-      "optional": false,
+      "optional": true,
       "encrypted": false
     }
   ],

--- a/urlhaus/requirements.txt
+++ b/urlhaus/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.4.0
 coverage==7.2.7
 pykson
 boto3==1.15.3
+requests>=2.28.0

--- a/urlhaus/tests/test_urlhaus.py
+++ b/urlhaus/tests/test_urlhaus.py
@@ -23,10 +23,16 @@ def test_test_connection_success(mock_post):
 
     result = connector.test_connection({
         "base_url": "https://urlhaus-api.abuse.ch/v1",
-        "auth_key": "dummy_key"
+        "api_key": "dummy_key"
     })
 
     assert result["status"] == "success"
+    mock_post.assert_called_once_with(
+        "https://urlhaus-api.abuse.ch/v1/url/",
+        headers={"Auth-Key": "dummy_key"},
+        data={"url": "https://example.com"},
+        timeout=30
+    )
 
 
 @patch("requests.post")
@@ -38,8 +44,30 @@ def test_test_connection_failure(mock_post):
     with pytest.raises(Exception):
         connector.test_connection({
             "base_url": "https://urlhaus-api.abuse.ch/v1",
-            "auth_key": "dummy_key"
+            "api_key": "dummy_key"
         })
+
+
+@patch("requests.post")
+def test_test_connection_no_api_key(mock_post):
+    mock_response = Mock()
+    mock_response.json.return_value = {"query_status": "no_results"}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    connector = Urlhaus()
+
+    result = connector.test_connection({
+        "base_url": "https://urlhaus-api.abuse.ch/v1"
+    })
+
+    assert result["status"] == "success"
+    mock_post.assert_called_once_with(
+        "https://urlhaus-api.abuse.ch/v1/url/",
+        headers={},
+        data={"url": "https://example.com"},
+        timeout=30
+    )
 
 
 # -------------------------------
@@ -48,13 +76,14 @@ def test_test_connection_failure(mock_post):
 @patch("requests.post")
 def test_url_reputation_malicious(mock_post):
     mock_response = Mock()
-    mock_response.json.return_value = {"query_status": "ok"}
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query_status": "ok", "threat": "malware_download"}
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
     connector = Urlhaus()
     request = DummyRequest(
-        {"base_url": "https://urlhaus-api.abuse.ch/v1", "auth_key": "key"},
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
         {"urls": "http://bad.com"}
     )
 
@@ -66,13 +95,14 @@ def test_url_reputation_malicious(mock_post):
 @patch("requests.post")
 def test_url_reputation_unknown(mock_post):
     mock_response = Mock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {"query_status": "no_results"}
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
     connector = Urlhaus()
     request = DummyRequest(
-        {"base_url": "https://urlhaus-api.abuse.ch/v1", "auth_key": "key"},
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
         {"urls": "http://clean.com"}
     )
 
@@ -81,19 +111,39 @@ def test_url_reputation_unknown(mock_post):
     assert result["results"][0]["reputation"] == "unknown"
 
 
-# -------------------------------
-# Host Reputation
-# -------------------------------
 @patch("requests.post")
-def test_host_reputation(mock_post):
+def test_url_reputation_suspicious(mock_post):
     mock_response = Mock()
-    mock_response.json.return_value = {"query_status": "ok"}
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query_status": "ok", "threat": "none", "url_status": "unknown"}
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
     connector = Urlhaus()
     request = DummyRequest(
-        {"base_url": "https://urlhaus-api.abuse.ch/v1", "auth_key": "key"},
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
+        {"urls": "http://maybe.com"}
+    )
+
+    result = connector.url_reputation(request)
+
+    assert result["results"][0]["reputation"] == "suspicious"
+
+
+# -------------------------------
+# Host Reputation
+# -------------------------------
+@patch("requests.post")
+def test_host_reputation_malicious(mock_post):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query_status": "ok", "url_count": 5}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    connector = Urlhaus()
+    request = DummyRequest(
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
         {"hosts": "1.2.3.4"}
     )
 
@@ -102,19 +152,58 @@ def test_host_reputation(mock_post):
     assert result["results"][0]["reputation"] == "malicious"
 
 
-# -------------------------------
-# Domain Reputation
-# -------------------------------
 @patch("requests.post")
-def test_domain_reputation(mock_post):
+def test_host_reputation_unknown(mock_post):
     mock_response = Mock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {"query_status": "no_results"}
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
     connector = Urlhaus()
     request = DummyRequest(
-        {"base_url": "https://urlhaus-api.abuse.ch/v1", "auth_key": "key"},
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
+        {"hosts": "8.8.8.8"}
+    )
+
+    result = connector.host_reputation(request)
+
+    assert result["results"][0]["reputation"] == "unknown"
+
+
+# -------------------------------
+# Domain Reputation (uses /host/ endpoint)
+# -------------------------------
+@patch("requests.post")
+def test_domain_reputation_malicious(mock_post):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query_status": "ok", "url_count": 3}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    connector = Urlhaus()
+    request = DummyRequest(
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
+        {"domains": "evil.com"}
+    )
+
+    result = connector.domain_reputation(request)
+
+    assert result["results"][0]["reputation"] == "malicious"
+
+
+@patch("requests.post")
+def test_domain_reputation_unknown(mock_post):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query_status": "no_results"}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    connector = Urlhaus()
+    request = DummyRequest(
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
         {"domains": "example.com"}
     )
 
@@ -127,18 +216,38 @@ def test_domain_reputation(mock_post):
 # File Reputation
 # -------------------------------
 @patch("requests.post")
-def test_file_reputation(mock_post):
+def test_file_reputation_malicious(mock_post):
     mock_response = Mock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {"query_status": "ok"}
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
     connector = Urlhaus()
     request = DummyRequest(
-        {"base_url": "https://urlhaus-api.abuse.ch/v1", "auth_key": "key"},
-        {"sha256_hashes": "dummyhash"}
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
+        {"sha256_hashes": "a" * 64}
     )
 
     result = connector.file_reputation(request)
 
     assert result["results"][0]["reputation"] == "malicious"
+
+
+@patch("requests.post")
+def test_file_reputation_unknown(mock_post):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query_status": "no_results"}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    connector = Urlhaus()
+    request = DummyRequest(
+        {"base_url": "https://urlhaus-api.abuse.ch/v1", "api_key": "key"},
+        {"sha256_hashes": "b" * 64}
+    )
+
+    result = connector.file_reputation(request)
+
+    assert result["results"][0]["reputation"] == "unknown"


### PR DESCRIPTION
- Fix auth_key -> api_key parameter name mismatch
- Send Auth-Key as HTTP header instead of POST body
- Add timeout=30 to all HTTP requests
- Add proper error handling (ConnectionError, Timeout, HTTPError)
- Fix domain_reputation to use /host/ endpoint (no /domain/ in URLhaus API)
- Refine reputation logic: online=malicious, offline=suspicious, no_results=unknown
- Explicitly handle unexpected query_status as error
- Unify reputation logic via _determine_reputation across all actions
- Add requests>=2.28.0 to requirements.txt
- Make api_key optional in integration_definition.json
- Update tests with proper mocks and new test cases