### PR TITLE
fix: remove pinned pykson version to prevent DecimalField ImportError

### DIFF
--- a/wiz/requirements.txt
+++ b/wiz/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.32.3
-pykson==0.9.9
+pykson
 pytest==8.3.5
 coverage==7.8.0


### PR DESCRIPTION
wiz/requirements.txt pinned pykson==0.9.9 which downgrades the pykson==0.9.9.8.17 installed by the py-service app/requirements.txt. Version 0.9.9 lacks DecimalField, causing ImportError at startup.