### PR TITLE
SOAR-12171: Add Block URL, Block Domain, Block IP, Block File Hash ac…

### DIFF
--- a/netskope/app/netskope.py
+++ b/netskope/app/netskope.py
@@ -1,6 +1,8 @@
 from app.model.request_body import RequestBody
 from app.model.response_body import ResponseBody
+import ipaddress
 import logging
+import re
 import time
 import requests
 
@@ -10,7 +12,13 @@ VALID_ALERT_TYPES = {
     "dlp", "malware", "policy", "security_assessment",
     "compromised_credential", "watchlist", "quarantine", "remediation", "uba",
 }
-VALID_URL_ACTIONS = {"append", "replace"}
+VALID_URL_TYPES = {"exact", "regex"}
+VALID_HASH_TYPES = {"md5", "sha256"}
+_RE_DOMAIN = re.compile(
+    r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$"
+)
+_RE_MD5 = re.compile(r"^[0-9a-fA-F]{32}$")
+_RE_SHA256 = re.compile(r"^[0-9a-fA-F]{64}$")
 
 MAX_RETRIES = 3
 BACKOFF_FACTOR = 2
@@ -54,7 +62,7 @@ class Netskope():
         return {
             "base_url": f"https://{tenant_hostname}",
             "headers": {
-                "Netskope-API-Token": api_token,
+                "Netskope-Api-Token": api_token,
                 "Content-Type": "application/json",
                 "User-Agent": USER_AGENT,
             },
@@ -292,33 +300,157 @@ class Netskope():
             self.logger.error("Error in get_alert_details", exc_info=e)
             raise Exception(str(e))
 
-    def update_url_list(self, request: RequestBody) -> ResponseBody:
+    def _append_urllist_and_deploy(self, config: dict, list_id: int, items: list, url_type: str) -> dict:
+        endpoint = f"/api/v2/policy/urllist/{list_id}/append"
+        body = {"data": {"urls": items, "type": url_type}}
+        self._make_request(config, "PATCH", endpoint, json_body=body)
+        self._make_request(config, "POST", "/api/v2/policy/urllist/deploy")
+        return {"status": "success", "list_id": list_id, "items_added": items}
+
+    def block_url(self, request: RequestBody) -> ResponseBody:
         try:
             config = self._get_config(request.connectionParameters)
             params = request.parameters
 
-            list_id = (params.get("list_id") or "").strip()
-            if not list_id:
-                raise Exception("list_id is required.")
+            raw_list_id = params.get("list_id")
+            try:
+                list_id = int(raw_list_id)
+                if list_id < 1:
+                    raise ValueError()
+            except (ValueError, TypeError):
+                raise Exception("list_id must be a positive integer.")
 
-            action = (params.get("action") or "").strip().lower()
-            if not action:
-                raise Exception("action is required.")
-            if action not in VALID_URL_ACTIONS:
-                raise Exception(f"action must be one of: {', '.join(sorted(VALID_URL_ACTIONS))}")
-
-            urls = (params.get("urls") or "").strip()
+            raw_urls = params.get("urls") or ""
+            if isinstance(raw_urls, list):
+                urls = [u.strip() for u in raw_urls if str(u).strip()]
+            else:
+                urls = [u.strip() for u in str(raw_urls).split(",") if u.strip()]
             if not urls:
-                raise Exception("urls is required.")
-            url_list = [u.strip() for u in urls.split(",") if u.strip()]
-            if not url_list:
-                raise Exception("urls must contain at least one valid URL.")
+                raise Exception("urls must contain at least one value.")
 
-            endpoint = f"/api/v2/policy/urllist/{list_id}/{action}"
-            body = {"urls": url_list}
+            url_type = (params.get("type") or "exact").strip().lower()
+            if url_type not in VALID_URL_TYPES:
+                raise Exception(f"type must be one of: {', '.join(sorted(VALID_URL_TYPES))}")
 
-            data = self._make_request(config, "PATCH", endpoint, json_body=body)
-            return {"status": "success", "result": data}
+            return self._append_urllist_and_deploy(config, list_id, urls, url_type)
         except Exception as e:
-            self.logger.error("Error in update_url_list", exc_info=e)
+            self.logger.error("Error in block_url", exc_info=e)
             raise Exception(str(e))
+
+    def block_domain(self, request: RequestBody) -> ResponseBody:
+        try:
+            config = self._get_config(request.connectionParameters)
+            params = request.parameters
+
+            raw_list_id = params.get("list_id")
+            try:
+                list_id = int(raw_list_id)
+                if list_id < 1:
+                    raise ValueError()
+            except (ValueError, TypeError):
+                raise Exception("list_id must be a positive integer.")
+
+            raw_domains = params.get("domains") or ""
+            if isinstance(raw_domains, list):
+                domains = [d.strip() for d in raw_domains if str(d).strip()]
+            else:
+                domains = [d.strip() for d in str(raw_domains).split(",") if d.strip()]
+            if not domains:
+                raise Exception("domains must contain at least one value.")
+
+            invalid = [d for d in domains if not _RE_DOMAIN.match(d)]
+            if invalid:
+                raise Exception(f"Invalid domain(s): {', '.join(invalid)}")
+
+            url_type = (params.get("type") or "exact").strip().lower()
+            if url_type not in VALID_URL_TYPES:
+                raise Exception(f"type must be one of: {', '.join(sorted(VALID_URL_TYPES))}")
+
+            return self._append_urllist_and_deploy(config, list_id, domains, url_type)
+        except Exception as e:
+            self.logger.error("Error in block_domain", exc_info=e)
+            raise Exception(str(e))
+
+    def block_ip(self, request: RequestBody) -> ResponseBody:
+        try:
+            config = self._get_config(request.connectionParameters)
+            params = request.parameters
+
+            raw_list_id = params.get("list_id")
+            try:
+                list_id = int(raw_list_id)
+                if list_id < 1:
+                    raise ValueError()
+            except (ValueError, TypeError):
+                raise Exception("list_id must be a positive integer.")
+
+            raw_ips = params.get("ips") or ""
+            if isinstance(raw_ips, list):
+                ips = [i.strip() for i in raw_ips if str(i).strip()]
+            else:
+                ips = [i.strip() for i in str(raw_ips).split(",") if i.strip()]
+            if not ips:
+                raise Exception("ips must contain at least one value.")
+
+            invalid = []
+            for ip in ips:
+                try:
+                    ipaddress.ip_network(ip, strict=False)
+                except ValueError:
+                    invalid.append(ip)
+            if invalid:
+                raise Exception(f"Invalid IP/CIDR value(s): {', '.join(invalid)}")
+
+            return self._append_urllist_and_deploy(config, list_id, ips, "exact")
+        except Exception as e:
+            self.logger.error("Error in block_ip", exc_info=e)
+            raise Exception(str(e))
+
+    def block_file_hash(self, request: RequestBody) -> ResponseBody:
+        try:
+            config = self._get_config(request.connectionParameters)
+            params = request.parameters
+
+            file_hash_list_name = (params.get("file_hash_list_name") or "").strip()
+            if not file_hash_list_name:
+                raise Exception("file_hash_list_name is required.")
+
+            raw_hashes = params.get("hashes") or ""
+            if isinstance(raw_hashes, list):
+                hashes = [h.strip() for h in raw_hashes if str(h).strip()]
+            else:
+                hashes = [h.strip() for h in str(raw_hashes).split(",") if h.strip()]
+            if not hashes:
+                raise Exception("hashes must contain at least one value.")
+
+            hash_type = (params.get("hash_type") or "").strip().lower()
+            if hash_type and hash_type not in VALID_HASH_TYPES:
+                raise Exception(f"hash_type must be one of: {', '.join(sorted(VALID_HASH_TYPES))}")
+
+            invalid = []
+            for h in hashes:
+                if not (_RE_MD5.match(h) or _RE_SHA256.match(h)):
+                    invalid.append(h)
+                elif hash_type == "md5" and not _RE_MD5.match(h):
+                    invalid.append(h)
+                elif hash_type == "sha256" and not _RE_SHA256.match(h):
+                    invalid.append(h)
+            if invalid:
+                raise Exception(f"Invalid hash value(s): {', '.join(invalid)}")
+
+            data = self._make_request(
+                config, "POST", "/api/v1/updateFileHashList",
+                params={"name": file_hash_list_name},
+                json_body={"list": ",".join(hashes)},
+            )
+            return {
+                "status": "success",
+                "file_hash_list": file_hash_list_name,
+                "hashes_added": hashes,
+                "result": data,
+            }
+        except Exception as e:
+            self.logger.error("Error in block_file_hash", exc_info=e)
+            raise Exception(str(e))
+
+

--- a/netskope/integration_definition.json
+++ b/netskope/integration_definition.json
@@ -299,16 +299,16 @@
         ]
       },
       {
-        "label": "Update URL List",
-        "name": "update_url_list",
-        "type": "Action",
-        "desc": "Add or replace URLs in a custom URL list (response/remediation action)",
+        "label": "Block URL",
+        "name": "block_url",
+        "type": "Containment",
+        "desc": "Append URLs to a Netskope URL list and deploy the policy",
         "sampleOutput": "",
         "inParameters": [
           {
             "label": "List ID",
             "name": "list_id",
-            "desc": "ID of the URL list to modify",
+            "desc": "ID of the URL list to append to",
             "type": "String",
             "values": [],
             "isSecret": false,
@@ -316,19 +316,111 @@
             "encrypted": false
           },
           {
-            "label": "Action",
-            "name": "action",
-            "desc": "Operation to perform on the URL list",
+            "label": "URLs",
+            "name": "urls",
+            "desc": "Comma-separated list of URLs to block",
             "type": "String",
-            "values": ["append", "replace"],
+            "values": [],
             "isSecret": false,
             "optional": false,
             "encrypted": false
           },
           {
-            "label": "URLs",
-            "name": "urls",
-            "desc": "Comma-separated list of URLs to add or replace",
+            "label": "Type",
+            "name": "type",
+            "desc": "Match type for the URL entries (default: exact)",
+            "type": "String",
+            "values": ["exact", "regex"],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          }
+        ],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "Confirmation with list_id and items_added",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "Block Domain",
+        "name": "block_domain",
+        "type": "Containment",
+        "desc": "Append validated domains to a Netskope URL list and deploy the policy",
+        "sampleOutput": "",
+        "inParameters": [
+          {
+            "label": "List ID",
+            "name": "list_id",
+            "desc": "ID of the URL list to append to",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          },
+          {
+            "label": "Domains",
+            "name": "domains",
+            "desc": "Comma-separated list of domains to block",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          },
+          {
+            "label": "Type",
+            "name": "type",
+            "desc": "Match type for the domain entries (default: exact)",
+            "type": "String",
+            "values": ["exact", "regex"],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          }
+        ],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "Confirmation with list_id and items_added",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "Block IP",
+        "name": "block_ip",
+        "type": "Containment",
+        "desc": "Append validated IPv4/IPv6/CIDR addresses to a Netskope URL list and deploy the policy",
+        "sampleOutput": "",
+        "inParameters": [
+          {
+            "label": "List ID",
+            "name": "list_id",
+            "desc": "ID of the URL list to append to",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          },
+          {
+            "label": "IPs",
+            "name": "ips",
+            "desc": "Comma-separated list of IPv4, IPv6, or CIDR addresses to block",
             "type": "String",
             "values": [],
             "isSecret": false,
@@ -340,7 +432,58 @@
           {
             "label": "Results",
             "name": "results",
-            "desc": "Updated URL list confirmation",
+            "desc": "Confirmation with list_id and items_added",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          }
+        ]
+      },
+      {
+        "label": "Block File Hash",
+        "name": "block_file_hash",
+        "type": "Containment",
+        "desc": "Add MD5 or SHA256 file hashes to a Netskope File Hash List",
+        "sampleOutput": "",
+        "inParameters": [
+          {
+            "label": "File Hash List Name",
+            "name": "file_hash_list_name",
+            "desc": "Name of the existing File Hash List to update",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          },
+          {
+            "label": "Hashes",
+            "name": "hashes",
+            "desc": "Comma-separated list of MD5 or SHA256 hashes to block",
+            "type": "String",
+            "values": [],
+            "isSecret": false,
+            "optional": false,
+            "encrypted": false
+          },
+          {
+            "label": "Hash Type",
+            "name": "hash_type",
+            "desc": "Expected hash type for validation (optional — auto-detected if omitted)",
+            "type": "String",
+            "values": ["md5", "sha256"],
+            "isSecret": false,
+            "optional": true,
+            "encrypted": false
+          }
+        ],
+        "outParameters": [
+          {
+            "label": "Results",
+            "name": "results",
+            "desc": "API response from Netskope File Hash List update",
             "type": "String",
             "values": [],
             "isSecret": false,

--- a/netskope/tests/test_netskope.py
+++ b/netskope/tests/test_netskope.py
@@ -46,7 +46,7 @@ class TestGetConfig:
         ns = Netskope()
         config = ns._get_config(_default_conn())
         assert config["base_url"] == "https://mytenant.goskope.com"
-        assert config["headers"]["Netskope-API-Token"] == "test-token-123"
+        assert config["headers"]["Netskope-Api-Token"] == "test-token-123"
         assert config["headers"]["User-Agent"] == "SecuronixSOAR-Netskope/1.0"
         assert config["timeout"] == 30
         assert config["verify"] is True
@@ -264,66 +264,6 @@ class TestGetAlertDetails:
             ns.get_alert_details(_mock_request_body(parameters=params))
 
 
-class TestUpdateUrlList:
-
-    @patch("app.netskope.requests.request")
-    def test_success_append(self, mock_req):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"status": "ok"}
-        mock_req.return_value = mock_resp
-
-        ns = Netskope()
-        params = {"list_id": "42", "action": "append", "urls": "http://evil.com,http://bad.com"}
-        result = ns.update_url_list(_mock_request_body(parameters=params))
-        assert result["status"] == "success"
-        assert "/api/v2/policy/urllist/42/append" in mock_req.call_args.kwargs["url"]
-        assert mock_req.call_args.kwargs["json"] == {"urls": ["http://evil.com", "http://bad.com"]}
-
-    @patch("app.netskope.requests.request")
-    def test_success_replace(self, mock_req):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"status": "ok"}
-        mock_req.return_value = mock_resp
-
-        ns = Netskope()
-        params = {"list_id": "10", "action": "replace", "urls": "http://only.com"}
-        result = ns.update_url_list(_mock_request_body(parameters=params))
-        assert result["status"] == "success"
-        assert "/api/v2/policy/urllist/10/replace" in mock_req.call_args.kwargs["url"]
-
-    def test_missing_list_id(self):
-        ns = Netskope()
-        params = {"action": "append", "urls": "http://test.com"}
-        with pytest.raises(Exception, match="list_id is required"):
-            ns.update_url_list(_mock_request_body(parameters=params))
-
-    def test_missing_action(self):
-        ns = Netskope()
-        params = {"list_id": "1", "urls": "http://test.com"}
-        with pytest.raises(Exception, match="action is required"):
-            ns.update_url_list(_mock_request_body(parameters=params))
-
-    def test_invalid_action(self):
-        ns = Netskope()
-        params = {"list_id": "1", "action": "delete", "urls": "http://test.com"}
-        with pytest.raises(Exception, match="action must be one of"):
-            ns.update_url_list(_mock_request_body(parameters=params))
-
-    def test_missing_urls(self):
-        ns = Netskope()
-        params = {"list_id": "1", "action": "append"}
-        with pytest.raises(Exception, match="urls is required"):
-            ns.update_url_list(_mock_request_body(parameters=params))
-
-    def test_empty_urls_after_split(self):
-        ns = Netskope()
-        params = {"list_id": "1", "action": "append", "urls": " , , "}
-        with pytest.raises(Exception, match="urls must contain at least one valid URL"):
-            ns.update_url_list(_mock_request_body(parameters=params))
-
-
 class TestErrorHandling:
 
     @patch("app.netskope.requests.request")
@@ -421,3 +361,369 @@ class TestErrorHandling:
         ns = Netskope()
         with pytest.raises(Exception, match="Validation error.*Invalid query syntax"):
             ns.get_alerts(_mock_request_body())
+
+
+class TestBlockUrl:
+
+    @patch("app.netskope.requests.request")
+    def test_success(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {"status": "ok"})
+        ns = Netskope()
+        params = {"list_id": "5", "urls": "http://evil.com,http://bad.org"}
+        result = ns.block_url(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+        assert result["list_id"] == 5
+        assert mock_req.call_count == 2
+        patch_call, deploy_call = mock_req.call_args_list
+        assert "/api/v2/policy/urllist/5/append" in patch_call.kwargs["url"]
+        assert patch_call.kwargs["json"] == {"data": {"urls": ["http://evil.com", "http://bad.org"], "type": "exact"}}
+        assert "/api/v2/policy/urllist/deploy" in deploy_call.kwargs["url"]
+
+    @patch("app.netskope.requests.request")
+    def test_success_regex_type(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "1", "urls": ".*evil\\.com", "type": "regex"}
+        result = ns.block_url(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+        assert mock_req.call_args_list[0].kwargs["json"]["data"]["type"] == "regex"
+
+    @patch("app.netskope.requests.request")
+    def test_success_list_input(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "3", "urls": ["http://a.com", "http://b.com"]}
+        result = ns.block_url(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+        assert result["items_added"] == ["http://a.com", "http://b.com"]
+
+    def test_missing_list_id(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="list_id must be a positive integer"):
+            ns.block_url(_mock_request_body(parameters={"urls": "http://x.com"}))
+
+    def test_invalid_list_id_zero(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="list_id must be a positive integer"):
+            ns.block_url(_mock_request_body(parameters={"list_id": "0", "urls": "http://x.com"}))
+
+    def test_empty_urls(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="urls must contain at least one value"):
+            ns.block_url(_mock_request_body(parameters={"list_id": "1", "urls": " , "}))
+
+    def test_invalid_type(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="type must be one of"):
+            ns.block_url(_mock_request_body(parameters={"list_id": "1", "urls": "http://x.com", "type": "wildcard"}))
+
+    @patch("app.netskope.requests.request")
+    def test_auth_failure(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=401)
+        ns = Netskope()
+        with pytest.raises(Exception, match="Authentication failed"):
+            ns.block_url(_mock_request_body(parameters={"list_id": "1", "urls": "http://x.com"}))
+
+    @patch("app.netskope.requests.request")
+    @patch("app.netskope.time.sleep")
+    def test_rate_limit_retry(self, mock_sleep, mock_req):
+        mock_429 = MagicMock(status_code=429, headers={"Retry-After": "2"})
+        mock_200 = MagicMock(status_code=200, json=lambda: {})
+        mock_req.side_effect = [mock_429, mock_200, mock_200]
+        ns = Netskope()
+        result = ns.block_url(_mock_request_body(parameters={"list_id": "1", "urls": "http://x.com"}))
+        assert result["status"] == "success"
+        mock_sleep.assert_called_once_with(2)
+
+    @patch("app.netskope.requests.request")
+    @patch("app.netskope.time.sleep")
+    def test_deploy_fails_on_server_error(self, mock_sleep, mock_req):
+        mock_200 = MagicMock(status_code=200, json=lambda: {})
+        mock_503 = MagicMock(status_code=503)
+        mock_req.side_effect = [mock_200, mock_503, mock_503, mock_503]
+        ns = Netskope()
+        with pytest.raises(Exception, match="Netskope server error"):
+            ns.block_url(_mock_request_body(parameters={"list_id": "1", "urls": "http://x.com"}))
+
+
+class TestBlockDomain:
+
+    @patch("app.netskope.requests.request")
+    def test_success(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "7", "domains": "evil.com,malicious.org"}
+        result = ns.block_domain(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+        assert result["list_id"] == 7
+        assert mock_req.call_count == 2
+        assert mock_req.call_args_list[0].kwargs["json"]["data"]["urls"] == ["evil.com", "malicious.org"]
+
+    @patch("app.netskope.requests.request")
+    def test_success_list_input(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "2", "domains": ["bad.net", "threat.io"]}
+        result = ns.block_domain(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+
+    def test_missing_list_id(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="list_id must be a positive integer"):
+            ns.block_domain(_mock_request_body(parameters={"domains": "evil.com"}))
+
+    def test_empty_domains(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="domains must contain at least one value"):
+            ns.block_domain(_mock_request_body(parameters={"list_id": "1", "domains": ""}))
+
+    def test_invalid_domain(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="Invalid domain"):
+            ns.block_domain(_mock_request_body(parameters={"list_id": "1", "domains": "not_a_domain,evil.com"}))
+
+    def test_ip_address_rejected_as_domain(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="Invalid domain"):
+            ns.block_domain(_mock_request_body(parameters={"list_id": "1", "domains": "1.2.3.4"}))
+
+    def test_invalid_type(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="type must be one of"):
+            ns.block_domain(_mock_request_body(parameters={"list_id": "1", "domains": "evil.com", "type": "glob"}))
+
+    @patch("app.netskope.requests.request")
+    def test_auth_failure(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=403)
+        ns = Netskope()
+        with pytest.raises(Exception, match="Authentication failed"):
+            ns.block_domain(_mock_request_body(parameters={"list_id": "1", "domains": "evil.com"}))
+
+    @patch("app.netskope.requests.request")
+    @patch("app.netskope.time.sleep")
+    def test_rate_limit_exhausted(self, mock_sleep, mock_req):
+        mock_req.return_value = MagicMock(status_code=429, headers={})
+        ns = Netskope()
+        with pytest.raises(Exception, match="Rate limit exceeded"):
+            ns.block_domain(_mock_request_body(parameters={"list_id": "1", "domains": "evil.com"}))
+
+
+class TestBlockIp:
+
+    @patch("app.netskope.requests.request")
+    def test_success_ipv4(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "3", "ips": "1.2.3.4,5.6.7.8"}
+        result = ns.block_ip(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+        assert result["items_added"] == ["1.2.3.4", "5.6.7.8"]
+        assert mock_req.call_count == 2
+
+    @patch("app.netskope.requests.request")
+    def test_success_ipv6(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "3", "ips": "2001:db8::1"}
+        result = ns.block_ip(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+
+    @patch("app.netskope.requests.request")
+    def test_success_cidr(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "3", "ips": "10.0.0.0/24,192.168.1.0/16"}
+        result = ns.block_ip(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+
+    @patch("app.netskope.requests.request")
+    def test_success_list_input(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {"list_id": "4", "ips": ["1.1.1.1", "8.8.8.8"]}
+        result = ns.block_ip(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+
+    def test_missing_list_id(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="list_id must be a positive integer"):
+            ns.block_ip(_mock_request_body(parameters={"ips": "1.2.3.4"}))
+
+    def test_empty_ips(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="ips must contain at least one value"):
+            ns.block_ip(_mock_request_body(parameters={"list_id": "1", "ips": ""}))
+
+    def test_invalid_ip(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="Invalid IP/CIDR"):
+            ns.block_ip(_mock_request_body(parameters={"list_id": "1", "ips": "999.999.999.999,1.2.3.4"}))
+
+    def test_domain_rejected_as_ip(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="Invalid IP/CIDR"):
+            ns.block_ip(_mock_request_body(parameters={"list_id": "1", "ips": "evil.com"}))
+
+    @patch("app.netskope.requests.request")
+    def test_auth_failure(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=401)
+        ns = Netskope()
+        with pytest.raises(Exception, match="Authentication failed"):
+            ns.block_ip(_mock_request_body(parameters={"list_id": "1", "ips": "1.2.3.4"}))
+
+    @patch("app.netskope.requests.request")
+    @patch("app.netskope.time.sleep")
+    def test_rate_limit_retry(self, mock_sleep, mock_req):
+        mock_429 = MagicMock(status_code=429, headers={"Retry-After": "3"})
+        mock_200 = MagicMock(status_code=200, json=lambda: {})
+        mock_req.side_effect = [mock_429, mock_200, mock_200]
+        ns = Netskope()
+        result = ns.block_ip(_mock_request_body(parameters={"list_id": "1", "ips": "1.2.3.4"}))
+        assert result["status"] == "success"
+        mock_sleep.assert_called_once_with(3)
+
+    @patch("app.netskope.requests.request")
+    @patch("app.netskope.time.sleep")
+    def test_server_error(self, mock_sleep, mock_req):
+        mock_req.return_value = MagicMock(status_code=500)
+        ns = Netskope()
+        with pytest.raises(Exception, match="Netskope server error"):
+            ns.block_ip(_mock_request_body(parameters={"list_id": "1", "ips": "1.2.3.4"}))
+
+
+class TestBlockFileHash:
+
+    @patch("app.netskope.requests.request")
+    def test_success_md5(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {"status": "success"})
+        ns = Netskope()
+        params = {
+            "file_hash_list_name": "malware-hashes",
+            "hashes": "d41d8cd98f00b204e9800998ecf8427e",
+            "hash_type": "md5",
+        }
+        result = ns.block_file_hash(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+        assert result["file_hash_list"] == "malware-hashes"
+        assert result["hashes_added"] == ["d41d8cd98f00b204e9800998ecf8427e"]
+        call = mock_req.call_args
+        assert "/api/v1/updateFileHashList" in call.kwargs["url"]
+        assert call.kwargs["params"]["name"] == "malware-hashes"
+        assert call.kwargs["json"]["list"] == "d41d8cd98f00b204e9800998ecf8427e"
+        assert call.kwargs["json"].get("hash_type") is None  # hash_type not in body
+
+    @patch("app.netskope.requests.request")
+    def test_success_sha256(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {
+            "file_hash_list_name": "threat-hashes",
+            "hashes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "hash_type": "sha256",
+        }
+        result = ns.block_file_hash(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+
+    @patch("app.netskope.requests.request")
+    def test_success_no_hash_type(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {
+            "file_hash_list_name": "mixed-hashes",
+            "hashes": "d41d8cd98f00b204e9800998ecf8427e",
+        }
+        result = ns.block_file_hash(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+        assert result["file_hash_list"] == "mixed-hashes"
+        assert "hash_type" not in mock_req.call_args.kwargs["json"]
+
+    @patch("app.netskope.requests.request")
+    def test_success_list_input(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {})
+        ns = Netskope()
+        params = {
+            "file_hash_list_name": "list1",
+            "hashes": ["d41d8cd98f00b204e9800998ecf8427e", "d41d8cd98f00b204e9800998ecf8427e"],
+        }
+        result = ns.block_file_hash(_mock_request_body(parameters=params))
+        assert result["status"] == "success"
+
+    def test_missing_file_hash_list_name(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="file_hash_list_name is required"):
+            ns.block_file_hash(_mock_request_body(parameters={"hashes": "d41d8cd98f00b204e9800998ecf8427e"}))
+
+    def test_empty_hashes(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="hashes must contain at least one value"):
+            ns.block_file_hash(_mock_request_body(parameters={"file_hash_list_name": "list1", "hashes": ""}))
+
+    def test_invalid_hash_type(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="hash_type must be one of"):
+            ns.block_file_hash(_mock_request_body(parameters={
+                "file_hash_list_name": "list1",
+                "hashes": "d41d8cd98f00b204e9800998ecf8427e",
+                "hash_type": "sha1",
+            }))
+
+    def test_invalid_hash_format(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="Invalid hash value"):
+            ns.block_file_hash(_mock_request_body(parameters={
+                "file_hash_list_name": "list1",
+                "hashes": "not-a-hash",
+            }))
+
+    def test_md5_hash_rejected_when_sha256_type(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="Invalid hash value"):
+            ns.block_file_hash(_mock_request_body(parameters={
+                "file_hash_list_name": "list1",
+                "hashes": "d41d8cd98f00b204e9800998ecf8427e",
+                "hash_type": "sha256",
+            }))
+
+    def test_sha256_hash_rejected_when_md5_type(self):
+        ns = Netskope()
+        with pytest.raises(Exception, match="Invalid hash value"):
+            ns.block_file_hash(_mock_request_body(parameters={
+                "file_hash_list_name": "list1",
+                "hashes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "hash_type": "md5",
+            }))
+
+    @patch("app.netskope.requests.request")
+    def test_auth_failure(self, mock_req):
+        mock_req.return_value = MagicMock(status_code=401)
+        ns = Netskope()
+        with pytest.raises(Exception, match="Authentication failed"):
+            ns.block_file_hash(_mock_request_body(parameters={
+                "file_hash_list_name": "list1",
+                "hashes": "d41d8cd98f00b204e9800998ecf8427e",
+            }))
+
+    @patch("app.netskope.requests.request")
+    @patch("app.netskope.time.sleep")
+    def test_rate_limit_retry(self, mock_sleep, mock_req):
+        mock_429 = MagicMock(status_code=429, headers={"Retry-After": "1"})
+        mock_200 = MagicMock(status_code=200, json=lambda: {})
+        mock_req.side_effect = [mock_429, mock_200]
+        ns = Netskope()
+        result = ns.block_file_hash(_mock_request_body(parameters={
+            "file_hash_list_name": "list1",
+            "hashes": "d41d8cd98f00b204e9800998ecf8427e",
+        }))
+        assert result["status"] == "success"
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("app.netskope.requests.request")
+    @patch("app.netskope.time.sleep")
+    def test_server_error(self, mock_sleep, mock_req):
+        mock_req.return_value = MagicMock(status_code=500)
+        ns = Netskope()
+        with pytest.raises(Exception, match="Netskope server error"):
+            ns.block_file_hash(_mock_request_body(parameters={
+                "file_hash_list_name": "list1",
+                "hashes": "d41d8cd98f00b204e9800998ecf8427e",
+            }))


### PR DESCRIPTION
…tions to Netskope connector

- Add block_url, block_domain, block_ip via shared _append_urllist_and_deploy helper (PATCH /api/v2/policy/urllist/{id}/append + POST /api/v2/policy/urllist/deploy)
- Add block_file_hash via POST /api/v1/updateFileHashList with name as query param
- Validate domains (regex), IPs/CIDRs (ipaddress module), MD5/SHA256 hashes
- Remove update_url_list (inconsistent with documented API, replaced by block_url)
- Fix header casing: Netskope-Api-Token
